### PR TITLE
chore: add CI status and license badges to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://github.com/hsel-netsys/iceflow/actions/workflows/build.yml/badge.svg)](https://github.com/hsel-netsys/iceflow/actions/workflows/build.yml)
+![License](https://img.shields.io/github/license/hsel-netsys/iceflow)
 
 # IceFlow
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://github.com/hsel-netsys/iceflow/actions/workflows/build.yml/badge.svg)](https://github.com/hsel-netsys/iceflow/actions/workflows/build.yml)
+
 # IceFlow
 
 This repository contains IceFlow, a stream processing library based on


### PR DESCRIPTION
This PR adds a build status indicator to the README file. It is not a substantial change, but I always like it when a project has some (meaningful) badges in its README.