### PR TITLE
test: set up basic test framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,15 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Verify Formatting
-        run: clang-format -i apps/**/*.cpp include/**/*.hpp --dry-run -Werror
+        run: clang-format -i apps/**/*.cpp tests/*.cpp include/**/*.hpp --dry-run -Werror
 
-      - name: Build IceFlow Applications
+      - name: Build IceFlow Example Applications and Tests
         run: |
-          cmake .
+          cmake -DBUILD_TESTS=ON .
           make
+
+      - name: Run Tests
+        run: make test
 
       - name: Export IceFlow Example Application Binaries
         uses: actions/upload-artifact@v3
@@ -64,10 +67,13 @@ jobs:
           sudo ./waf install
           cd ..
 
-      - name: Build IceFlow Example Applications
+      - name: Build IceFlow Example Applications and Tests
         run: |
-          cmake .
+          cmake -DBUILD_TESTS=ON .
           make
+
+      - name: Run Tests
+        run: make test
 
       - name: Export IceFlow Example Application Binaries
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Verify and Build
+name: Build Status
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,9 @@
 *.app
 
 ### JetBrains template
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, 
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm,
 CLion, Android Studio and Webstorm
-# Reference: 
+# Reference:
 https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff:
@@ -92,3 +92,9 @@ install_manifest.txt
 
 # Documentation folder
 docs/
+
+# CTest files
+*.tcl
+CTestTestfile.cmake
+Testing/
+test_build/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ Verify formatting with clang-format:
   script:
     - apt-get update
     - apt-get -y install clang-format
-    - clang-format -i apps/**/*.cpp include/**/*.hpp --dry-run -Werror
+    - clang-format -i apps/**/*.cpp tests/*.cpp include/**/*.hpp --dry-run -Werror
 
 build:
   stage: build
@@ -25,5 +25,6 @@ build:
         "src/PeopleCounter/peoplecounter",
       ]
   script:
-    - cmake .
+    - cmake -DBUILD_TESTS=ON .
     - make
+    - make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 if(BUILD_TESTS)
   message(STATUS "Building tests...")
   add_subdirectory(tests)
+  enable_testing()
 endif()
 
 install(FILES cmake/iceflow-config.cmake

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ After installing it (e.g., by using `brew install clang-format` on macOS) you
 can format all source files by invoking the following command:
 
 ```sh
-clang-format -i apps/**/*.cpp include/**/*.hpp
+clang-format -i apps/**/*.cpp tests/*.cpp include/**/*.hpp
 ```
 The CI pipeline will assert that the codebase is always correctly
 formatted and will fail otherwise.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright 2023 The IceFlow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+project(${CMAKE_PROJECT_NAME})
+
+include(CTest)
+
+set(TEST_FILES iceflow_test.cpp)
+
+foreach(TEST_FILE ${TEST_FILES})
+  get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
+
+  add_executable(${TEST_NAME} ${TEST_FILE})
+  set_target_properties(${TEST_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+                                                ../test_build)
+
+  target_link_libraries(${TEST_NAME} PRIVATE iceflow)
+  add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+endforeach(TEST_FILE ${TEST_FILES})

--- a/tests/iceflow_test.cpp
+++ b/tests/iceflow_test.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <iostream>
+
+int main() {
+  std::cout << "Test started!" << std::endl;
+  std::cout << "Test succeeded!" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
This PR adds the foundation for a basic testing workflow based on CMake's CTest. In follow-up PRs, this foundation can be extended to use a testing framework like Boost.Test or Google Test.