### PR TITLE
chore(ci): run macOS build only after Ubuntu build succeeded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
+    needs: build-ubuntu
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Since our Ubuntu workflow is much faster than the macOS one (due to the pre-build CI image), we can let the macOS workflow run only after Ubuntu workflow has succeeded. This lets the CI fail fast if there should be some kind of error and saves us some (more restricted) macOS run time.