### PR TITLE
feat: create Docker workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+cmake
+CMakeFiles
+CMakeCache.txt
+Install.md
+README.md
+Makefile
+

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,45 @@
+name: Create and publish Docker image
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'Dockerfile'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64, linux/arm/v7
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM ubuntu:latest
+COPY . /
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install git cmake wget software-properties-common build-essential pkg-config python3-minimal libssl-dev libsqlite3-dev libopencv-dev clang-format libboost-all-dev libpcap-dev libsystemd-dev && \
+    ln -s /usr/include/opencv4 /usr/local/include/opencv4 && \
+    # Install nlohmann-json
+    add-apt-repository ppa:team-xbmc/ppa &&  \
+    apt-get update && \
+    apt-get -y install nlohmann-json3-dev && \
+    # Install ndn-cxx
+    git clone https://github.com/named-data/ndn-cxx && \
+    cd ndn-cxx && \
+    ./waf configure && \
+    ./waf && \
+    ./waf install && \
+    ldconfig && \
+    cd .. && \
+    rm -rf ndn-cxx && \
+    # Install PSync
+    git clone https://github.com/named-data/PSync.git && \
+    cd PSync && \
+    ./waf configure && \
+    ./waf && \
+    ./waf install && \
+    cd .. && \
+    rm -rf PSync && \
+    # Install yaml-cpp
+    git clone https://github.com/jbeder/yaml-cpp.git && \
+    cd yaml-cpp && \
+    mkdir build && \
+    cd build && \
+    cmake -DYAML_BUILD_SHARED_LIBS=on .. && \
+    make && \
+    make install && \
+    cd ../.. && \
+    rm -rf yaml-cpp && \
+    # Build and install NFD
+    git clone --recursive https://github.com/named-data/NFD && \
+    cd NFD && \
+    ./waf configure && \
+    ./waf && \
+    ./waf install && \
+    ldconfig && \
+    cp /usr/local/etc/ndn/nfd.conf.sample /usr/local/etc/ndn/nfd.conf && \
+    cd .. && \
+    rm -rf NFD && \
+    # Build IceFlow
+    cmake .  && \
+    make
+
+ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that builds a Docker image containing both the NFD and our IceFlow applications. The images built should be compatible with the architecture our Raspberry Pis are using (armv7, if I am not mistaken), which could simplify the Deployment here.

This approach has to be considered somewhat experimental (especially when considering the question of whether or not the images will be usable with an Ethernet face), but I thought it would be useful to have this kind of infrastructure in place.