### PR TITLE
chore(ci): deploy Doxygen documentation via Action

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -5,10 +5,38 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: DenverCoder1/doxygen-github-pages-action@v1.3.0
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Doxygen
+        run: |
+         apt update
+         apt install doxygen doxygen-doc doxygen-gui graphviz
+      - name: Run Doxygen
+        run: doxygen
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          path: './docs/html'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
The way of deployment I tried to use before was somehow not working. This PR replaces it with the new, favored approach from GitHub, by using a dedicated action for deployment.

Since this does not affect the actual codebase, I will merge this PR right away.