### PR TITLE
refactor: remove membuf class

### DIFF
--- a/include/iceflow/block.hpp
+++ b/include/iceflow/block.hpp
@@ -61,8 +61,6 @@ public:
                                             resultSubElements[0].value_end());
     } else {
       NDN_LOG_INFO("pullJson Main data");
-      membuf m(m_data.value(), m_data.value_size());
-      std::istream in(&m);
       convertedJson =
           nlohmann::json::parse(m_data.value_begin(), m_data.value_end());
     }

--- a/include/iceflow/typed-data.hpp
+++ b/include/iceflow/typed-data.hpp
@@ -23,18 +23,6 @@
 
 namespace iceflow {
 
-class membuf : public std::basic_streambuf<char> {
-public:
-  membuf(const uint8_t *p, size_t l) {
-    setg((char *)p, (char *)p, (char *)p + l);
-    setp((char *)p, (char *)p + l);
-  }
-  int size() const { return this->pptr() - this->pbase(); };
-  uint8_t *getP() { return (uint8_t *)(gptr()); }
-  uint8_t *getBPtr() { return (uint8_t *)(eback()); }
-  uint8_t *getEPtr() { return (uint8_t *)(egptr()); }
-};
-
 // Abstract base class.
 class TypedData {
 public:


### PR DESCRIPTION
Having another look at the source code, I noticed that the `membuf` class is not actually being used and can simply be removed, which cleans up the codebase a bit more.