### PR TITLE
chore: integrate clang-format into CMake build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Generate CMake Build Files
+        run: cmake -DBUILD_TESTS=ON .
+
       - name: Verify Formatting
-        run: clang-format -i apps/**/*.cpp tests/*.cpp include/**/*.hpp --dry-run -Werror
+        run: make check-format
 
       - name: Build IceFlow Example Applications and Tests
-        run: |
-          cmake -DBUILD_TESTS=ON .
-          make
+        run: make
 
       - name: Run Tests
         run: make test
@@ -47,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Dependencies
-        run: brew install boost openssl pkg-config opencv nlohmann-json yaml-cpp
+        run: brew install boost openssl pkg-config opencv nlohmann-json yaml-cpp clang-format
 
       - name: Install ndn-cxx
         run: |
@@ -67,10 +68,14 @@ jobs:
           sudo ./waf install
           cd ..
 
+      - name: Generate CMake Build Files
+        run: cmake -DBUILD_TESTS=ON .
+
+      - name: Verify Formatting
+        run: make check-format
+
       - name: Build IceFlow Example Applications and Tests
-        run: |
-          cmake -DBUILD_TESTS=ON .
-          make
+        run: make
 
       - name: Run Tests
         run: make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ project(
   DESCRIPTION "NDN-based stream processing library written in C++.")
 set(CMAKE_CXX_STANDARD 20)
 
+include(cmake/formatting.cmake)
+
 add_subdirectory(include)
 
 option(BUILD_APPS "Build IceFlow applications" ON)

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ running the `doxygen` command in the repository's root directory.
 In order to achieve a consistent style, IceFlow's codebase is formatted using
 `clang-format`.
 After installing it (e.g., by using `brew install clang-format` on macOS) you
-can format all source files by invoking the following command:
+can format all source files by invoking the following commands:
 
 ```sh
-clang-format -i apps/**/*.cpp tests/*.cpp include/**/*.hpp
+cmake .
+make format
 ```
 The CI pipeline will assert that the codebase is always correctly
 formatted and will fail otherwise.

--- a/cmake/formatting.cmake
+++ b/cmake/formatting.cmake
@@ -1,0 +1,36 @@
+# Copyright 2023 The IceFlow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file introduces custom `format` and `check-format` targets which simplify
+# the process of formatting the project's source code as well as verifying it.
+#
+# After running `cmake .`, you can automatically format the codebase using `make
+# format`. To only check whether the codebase is properly formatted, run `make
+# check-format` instead.
+
+set(FORMATTING_SOURCES apps/**/*.cpp tests/*.cpp include/**/*.hpp)
+
+add_custom_target(format)
+add_custom_command(
+  TARGET format
+  COMMAND clang-format -i ${FORMATTING_SOURCES}
+  COMMENT "Formatting codebase...")
+
+add_custom_target(check-format)
+add_custom_command(
+  TARGET check-format
+  COMMAND clang-format -i ${FORMATTING_SOURCES} --dry-run -Werror
+  COMMENT "Verifying formatting...")


### PR DESCRIPTION
This PR simplifies the process of using clang-format for formatting the codebase using custom CMake build targets. The README as well as the CI workflows are updated accordingly.