### PR TITLE
chore(ci): run only one Docker image workflow at a time

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'Dockerfile'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Using the `concurrency` keyword, this PR adjusts the CI behavior to only build one Docker image per branch at a time, canceling previous runs. This prevents the CI from wasting time building outdated images.