### PR TITLE
Introduce "docs" CMake target for generating documentation

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -14,15 +14,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: ghcr.io/hsel-netsys/iceflow-ci-image:main
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Doxygen
-        run: |
-         sudo apt-get update
-         sudo apt-get install doxygen doxygen-doc doxygen-gui graphviz
-      - name: Run Doxygen
-        run: doxygen
+      - name: Generate Build Files
+        run: cmake .
+      - name: Build Documentation
+        run: make docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ project(
   DESCRIPTION "NDN-based stream processing library written in C++.")
 set(CMAKE_CXX_STANDARD 20)
 
+include(cmake/docs.cmake)
 include(cmake/format.cmake)
 include(cmake/lint.cmake)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/hsel-netsys/iceflow/actions/workflows/build.yml/badge.svg)](https://github.com/hsel-netsys/iceflow/actions/workflows/build.yml)
-[![Documentation Status](https://img.shields.io/github/actions/workflow/status/hsel-netsys/iceflow/doxygen-gh-pages.yml?label=Documentation&link=https%3A%2F%2Fhsel-netsys.github.io%2Ficeflow)](https://hsel-netsys.github.io/iceflow)
+[![Documentation Status](https://img.shields.io/github/actions/workflow/status/hsel-netsys/iceflow/doxygen-gh-pages.yml?label=docs&link=https%3A%2F%2Fhsel-netsys.github.io%2Ficeflow)](https://hsel-netsys.github.io/iceflow)
 ![License](https://img.shields.io/github/license/hsel-netsys/iceflow)
 
 # IceFlow

--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ Detailed installation instructions can be found in the file [Install.md](Install
 ## Documentation
 
 IceFlow's documentation can be found [here](https://hsel-netsys.github.io/iceflow).
-Alternatively, you can generate the documentation locally using Doxygen and
-running the `doxygen` command in the repository's root directory.
+
+If you Doxygen installed, you can generate the documentation locally using the
+following commands in the repository's root directory:
+
+```sh
+cmake .
+make docs
+```
 
 ## Code Style
 

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -1,0 +1,18 @@
+# Copyright 2023 The IceFlow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+add_custom_target(docs)
+add_custom_command(TARGET docs COMMAND doxygen Doxyfile)


### PR DESCRIPTION
This PR integrates the generation of the Doxygen documentation into the CMake build system. This simplifies documentation generation, as you can simply type `make docs` after generating the build files to create the Doxygen output. The CI and the README file is updated accordingly.