### PR TITLE
chore: lower minimum required CMake version to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.18)
 project(
   IceFlow
   VERSION 0.1.0

--- a/Install.md
+++ b/Install.md
@@ -25,7 +25,7 @@ The ndn-cxx library is the most important dependency for IceFlow, as it provides
 - Boost >= 1.71.0
 - OpenSSL >= 1.1.1
 - SQLite 3.x
-- CMake >= 3.21
+- CMake >= 3.18
 
 Under Ubuntu, you can install the requirements from the terminal using the following command:
 


### PR DESCRIPTION
In order to increase the set of compatible CMake versions (and less recent versions of Raspberry Pi OS), this PR lowers the minimum required CMake version to 3.18.