### PR TITLE
refactor: use CI image as basis for IceFlow Docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,8 +5,6 @@ on:
     branches: ['main']
   pull_request:
     branches: ['main']
-    paths:
-      - 'Dockerfile'
 
 concurrency:
   group: ${{ github.ref }}
@@ -39,11 +37,21 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Set platform variable
+        id: set-platform-vars
+        run: |
+          if [[ "${{github.ref}}" == "refs/heads/main" ]]; then
+            echo "PLATFORMS=linux/amd64, linux/arm/v7" >> "$GITHUB_OUTPUT"
+          else
+            echo "PLATFORMS=linux/amd64" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64, linux/arm/v7
+          platforms: ${{ steps.set-platform-vars.outputs.PLATFORMS }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,59 +1,6 @@
-FROM ubuntu:latest
+FROM ghcr.io/hsel-netsys/iceflow-ci-image:main
 COPY . /
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install git cmake wget software-properties-common build-essential pkg-config python3-minimal libssl-dev libsqlite3-dev libopencv-dev clang-format libboost-all-dev libpcap-dev libsystemd-dev psmisc sudo && \
-    ln -s /usr/include/opencv4 /usr/local/include/opencv4 && \
-    # Install nlohmann-json
-    add-apt-repository ppa:team-xbmc/ppa &&  \
-    apt-get update && \
-    apt-get -y install nlohmann-json3-dev && \
-    # Install ndn-cxx
-    git clone https://github.com/named-data/ndn-cxx && \
-    cd ndn-cxx && \
-    ./waf configure && \
-    ./waf && \
-    ./waf install && \
-    ldconfig && \
-    cd .. && \
-    rm -rf ndn-cxx && \
-    # Install PSync
-    git clone https://github.com/named-data/PSync.git && \
-    cd PSync && \
-    ./waf configure && \
-    ./waf && \
-    ./waf install && \
-    cd .. && \
-    rm -rf PSync && \
-    # Install yaml-cpp
-    git clone https://github.com/jbeder/yaml-cpp.git && \
-    cd yaml-cpp && \
-    mkdir build && \
-    cd build && \
-    cmake -DYAML_BUILD_SHARED_LIBS=on .. && \
-    make && \
-    make install && \
-    cd ../.. && \
-    rm -rf yaml-cpp && \
-    # Build and install NFD
-    git clone --recursive https://github.com/JKRhb/NFD-out-of-the-box.git NFD --branch self-learning-rebased && \
-    cd NFD && \
-    ./waf configure && \
-    ./waf && \
-    ./waf install && \
-    ldconfig && \
-    cp /usr/local/etc/ndn/nfd.conf.sample /usr/local/etc/ndn/nfd.conf && \
-    cd .. && \
-    rm -rf NFD && \
-    # Build and install NDN tools
-    git clone https://github.com/named-data/ndn-tools.git && \
-    cd ndn-tools && \
-    ./waf configure && \
-    ./waf && \
-    ./waf install && \
-    cd .. && \
-    rm -rf ndn-tools && \
-    # Build IceFlow
-    cmake .  && \
+RUN cmake . && \
     make
 
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
This should speed up the build time of the Docker image dramatically, as the CI is now not rebuilding the NFD every time but instead re-uses the CI image.