### PR TITLE
refactor!: move apps specific functions to util files

### DIFF
--- a/apps/AgeDetection/agedetection.cpp
+++ b/apps/AgeDetection/agedetection.cpp
@@ -26,6 +26,8 @@
 #include "iceflow/measurements.hpp"
 #include "iceflow/producer-tlv.hpp"
 
+#include "util.hpp"
+
 // ###### MEASUREMENT ######
 
 iceflow::Measurement *msCmp;
@@ -61,7 +63,7 @@ public:
       auto start = std::chrono::system_clock::now();
 
       auto inputData = input->waitAndPopValue();
-      auto frameData = inputData.pullFrame();
+      auto frameData = pullFrame(inputData);
       auto jsonData = inputData.pullJson();
       nlohmann::json jsonInput = jsonData.getJson();
 

--- a/apps/Aggregate/aggregate.cpp
+++ b/apps/Aggregate/aggregate.cpp
@@ -24,6 +24,8 @@
 #include "iceflow/consumer-tlv.hpp"
 #include "iceflow/measurements.hpp"
 
+#include "util.hpp"
+
 // ###### MEASUREMENT ######
 
 iceflow::Measurement *msCmp;

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -15,11 +15,11 @@ set(SOURCES
 foreach(SOURCE_FILE ${SOURCES})
   get_filename_component(EXECUTABLE_NAME ${SOURCE_FILE} NAME_WE)
   get_filename_component(EXECUTABLE_PATH ${SOURCE_FILE} DIRECTORY)
-  add_executable(${EXECUTABLE_NAME} ${SOURCE_FILE})
+  add_executable(${EXECUTABLE_NAME} ${SOURCE_FILE} util/util.cpp)
   set_target_properties(${EXECUTABLE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                                       ../build)
   target_include_directories(
-    ${EXECUTABLE_NAME} PRIVATE ../include ${NDN_CXX_INCLUDE_DIRS}
+    ${EXECUTABLE_NAME} PRIVATE ../include include ${NDN_CXX_INCLUDE_DIRS}
                                ${PSYNC_INCLUDE_DIRS} ${YAML_INCLUDE_DIRS})
   target_compile_options(${EXECUTABLE_NAME} PRIVATE -D_GNU_SOURCE
                                                     -DBOOST_LOG_DYN_LINK)

--- a/apps/FaceDetection/facedetection.cpp
+++ b/apps/FaceDetection/facedetection.cpp
@@ -25,6 +25,8 @@
 #include "iceflow/measurements.hpp"
 #include "iceflow/producer-tlv.hpp"
 
+#include "util.hpp"
+
 // ###### MEASUREMENT ######
 iceflow::Measurement *msCmp;
 
@@ -60,7 +62,7 @@ public:
       std::chrono::duration<double> popping_time =
           (std::chrono::system_clock::now().time_since_epoch());
 
-      auto frameData = inputData.pullFrame();
+      auto frameData = pullFrame(inputData);
       auto jsonData = inputData.pullJson();
       nlohmann::json inputJson = jsonData.getJson();
       NDN_LOG_INFO("Frame ID: " << inputJson["frameID"].get<int>());
@@ -81,7 +83,7 @@ public:
           NDN_LOG_DEBUG("Output Queue Size: " << output->size());
           iceflow::Block resultBlock;
           resultBlock.pushJson(jsonData);
-          resultBlock.pushFrame(face);
+          pushFrame(resultBlock, face);
           auto end = std::chrono::system_clock::now();
           std::chrono::duration<double> elapsedTime = (end - start);
           NDN_LOG_INFO("Face Detection Compute Time: " << elapsedTime.count());

--- a/apps/GenderDetection/genderdetection.cpp
+++ b/apps/GenderDetection/genderdetection.cpp
@@ -25,6 +25,8 @@
 #include "iceflow/measurements.hpp"
 #include "iceflow/producer-tlv.hpp"
 
+#include "util.hpp"
+
 // ###### MEASUREMENT ######
 iceflow::Measurement *msCmp;
 
@@ -55,7 +57,7 @@ public:
     while (true) {
 
       auto inputData = input->waitAndPopValue();
-      auto frameData = inputData.pullFrame();
+      auto frameData = pullFrame(inputData);
       auto jsonData = inputData.pullJson();
 
       nlohmann::json jsonInput = jsonData.getJson();

--- a/apps/ImageSource/imagesource.cpp
+++ b/apps/ImageSource/imagesource.cpp
@@ -25,6 +25,8 @@
 #include "iceflow/measurements.hpp"
 #include "iceflow/producer-tlv.hpp"
 
+#include "util.hpp"
+
 iceflow::Measurement *msCmp;
 
 void signalCallbackHandler(int signum) {
@@ -69,7 +71,7 @@ public:
       result.second = grayFrame;
 
       resultBlock.pushJson(m_jsonOutput);
-      resultBlock.pushFrameCompress(grayFrame);
+      pushFrameCompress(resultBlock, grayFrame);
       msCmp->setField(std::to_string(computeCounter), "CMP_FINISH", 0);
       // pass the frame and metaInfo to the producer Queue
 

--- a/apps/PeopleCounter/peoplecounter.cpp
+++ b/apps/PeopleCounter/peoplecounter.cpp
@@ -26,6 +26,8 @@
 #include "iceflow/measurements.hpp"
 #include "iceflow/producer-tlv.hpp"
 
+#include "util.hpp"
+
 // ###### MEASUREMENT ######
 
 iceflow::Measurement *msCmp;
@@ -52,7 +54,7 @@ public:
         NDN_LOG_DEBUG("Compute Input Queue Size: " << input->size());
         auto inputData = input->waitAndPopValue();
         auto start = std::chrono::system_clock::now();
-        auto frameData = inputData.pullFrame();
+        auto frameData = pullFrame(inputData);
         auto jsonData = inputData.pullJson();
         NDN_LOG_DEBUG("Input Json: " << jsonData.getJson());
 

--- a/apps/include/util.hpp
+++ b/apps/include/util.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ICEFLOW_APPS_UTIL_HPP
+#define ICEFLOW_APPS_UTIL_HPP
+
+#include "iceflow/block.hpp"
+#include "opencv2/opencv.hpp"
+
+void pushFrame(iceflow::Block block, cv::Mat frame);
+
+void pushFrameCompress(iceflow::Block block, cv::Mat frame);
+
+cv::Mat pullFrame(iceflow::Block block);
+
+#endif // ICEFLOW_APPS_UTIL_HPP

--- a/apps/util/util.cpp
+++ b/apps/util/util.cpp
@@ -42,18 +42,18 @@ cv::Mat pullFrame(iceflow::Block block) {
   // test type here instead of the first element
   if (resultSubElements.size() > 0) {
     NDN_LOG_INFO("pullFrame Manifest data");
-    for (int i = 0; i < resultSubElements.size(); i++) {
-      if (resultSubElements[i].type() ==
+    for (auto resultSubElement : resultSubElements) {
+      if (resultSubElement.type() ==
           iceflow::ContentTypeValue::SegmentManifest) {
-        std::vector<uint8_t> frameBuffer(resultSubElements[i].value_begin(),
-                                         resultSubElements[i].value_end());
+        std::vector<uint8_t> frameBuffer(resultSubElement.value_begin(),
+                                         resultSubElement.value_end());
         return imdecode(cv::Mat(frameBuffer), 1);
       }
     }
-  } else {
-    NDN_LOG_INFO("pullFrame Main data");
-    auto data = block.getData();
-    std::vector<uint8_t> frameBuffer(data.value_begin(), data.value_end());
-    return imdecode(cv::Mat(frameBuffer), 1);
   }
+
+  NDN_LOG_INFO("pullFrame Main data");
+  auto data = block.getData();
+  std::vector<uint8_t> frameBuffer(data.value_begin(), data.value_end());
+  return imdecode(cv::Mat(frameBuffer), 1);
 }

--- a/apps/util/util.cpp
+++ b/apps/util/util.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "util.hpp"
+#include "iceflow/content-type-value.hpp"
+
+void pushFrame(iceflow::Block block, cv::Mat frame) {
+  std::vector<uchar> buffer;
+  cv::imencode(".jpeg", frame, buffer);
+  std::vector<uint8_t> &frameBuffer =
+      reinterpret_cast<std::vector<uint8_t> &>(buffer);
+  block.pushSegmentManifestBlock(frameBuffer);
+}
+
+void pushFrameCompress(iceflow::Block block, cv::Mat frame) {
+  std::vector<uchar> buffer;
+  std::vector<int> param(2);
+  param[0] = cv::IMWRITE_JPEG_QUALITY;
+  param[1] = 10; // default(95) 0-100
+  cv::imencode(".jpeg", frame, buffer, param);
+  block.pushSegmentManifestBlock(buffer);
+}
+
+cv::Mat pullFrame(iceflow::Block block) {
+  std::vector<ndn::Block> resultSubElements = block.getSubElements();
+
+  // test type here instead of the first element
+  if (resultSubElements.size() > 0) {
+    NDN_LOG_INFO("pullFrame Manifest data");
+    for (int i = 0; i < resultSubElements.size(); i++) {
+      if (resultSubElements[i].type() ==
+          iceflow::ContentTypeValue::SegmentManifest) {
+        std::vector<uint8_t> frameBuffer(resultSubElements[i].value_begin(),
+                                         resultSubElements[i].value_end());
+        return imdecode(cv::Mat(frameBuffer), 1);
+      }
+    }
+  } else {
+    NDN_LOG_INFO("pullFrame Main data");
+    auto data = block.getData();
+    std::vector<uint8_t> frameBuffer(data.value_begin(), data.value_end());
+    return imdecode(cv::Mat(frameBuffer), 1);
+  }
+}

--- a/cmake/format.cmake
+++ b/cmake/format.cmake
@@ -21,7 +21,7 @@
 # format`. To only check whether the codebase is properly formatted, run `make
 # check-format` instead.
 
-set(FORMATTING_SOURCES apps/**/*.cpp tests/*.cpp include/**/*.hpp)
+set(FORMATTING_SOURCES apps/**/*.cpp  apps/**/*.hpp tests/*.cpp include/**/*.hpp)
 
 add_custom_target(format)
 add_custom_command(

--- a/include/iceflow/block.hpp
+++ b/include/iceflow/block.hpp
@@ -21,7 +21,6 @@
 
 #include "ndn-cxx/data.hpp"
 #include "nlohmann/json.hpp"
-#include "opencv2/opencv.hpp" // TODO: Remove this dependency
 
 #include "content-type-value.hpp"
 #include "logger.hpp"
@@ -62,43 +61,7 @@ public:
     return outputJson;
   }
 
-  void pushFrame(cv::Mat frame) {
-    std::vector<uchar> buffer;
-    cv::imencode(".jpeg", frame, buffer);
-    pushSegmentManifestBlock(buffer);
-  }
-
-  void pushFrameCompress(cv::Mat frame) {
-    std::vector<uchar> buffer;
-    std::vector<int> param(2);
-    param[0] = cv::IMWRITE_JPEG_QUALITY;
-    param[1] = 10; // default(95) 0-100
-    cv::imencode(".jpeg", frame, buffer, param);
-    pushSegmentManifestBlock(buffer);
-  }
-
-  cv::Mat pullFrame() {
-    std::vector<ndn::Block> resultSubElements = m_data.elements();
-
-    // test type here instead of the first element
-    if (resultSubElements.size() > 0) {
-      for (int i = 0; i < resultSubElements.size(); i++) {
-        if (resultSubElements[i].type() == ContentTypeValue::SegmentManifest) {
-          std::vector<uint8_t> frameBuffer(resultSubElements[i].value_begin(),
-                                           resultSubElements[i].value_end());
-          return imdecode(cv::Mat(frameBuffer), 1);
-        }
-      }
-    } else {
-      std::vector<uint8_t> frameBuffer(m_data.value_begin(),
-                                       m_data.value_end());
-      return imdecode(cv::Mat(frameBuffer), 1);
-    }
-  }
-
-  void pushSegmentManifestBlock(std::vector<uchar> &buffer) {
-    std::vector<uint8_t> &frameBuffer =
-        reinterpret_cast<std::vector<uint8_t> &>(buffer);
+  void pushSegmentManifestBlock(std::vector<uint8_t> &buffer) {
     ndn::Block frameContent = ndn::encoding::makeBinaryBlock(
         ContentTypeValue::SegmentManifest, buffer);
     pushBlock(frameContent);

--- a/include/iceflow/block.hpp
+++ b/include/iceflow/block.hpp
@@ -74,6 +74,8 @@ public:
 
   std::vector<ndn::Block> getSubElements() { return m_data.elements(); }
 
+  ndn::Block getData() { return m_data; }
+
 private:
   ndn::Block m_data;
 };


### PR DESCRIPTION
This PR resolves #24 by moving the OpenCV-specific helper functions to `util` files specific to the currently defined `apps`.