### PR TITLE
feat: install IceFlow as library in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/hsel-netsys/iceflow-ci-image:main
 COPY . /
 RUN cmake . && \
-    make
+    make && \
+    make install
 
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
This PR lets the Dockerfile invoke `make install`, making it possible to use IceFlow as a library in other inheriting Docker images.