### PR TITLE
fix: correctly pass Block to pushFrame functions

### DIFF
--- a/apps/FaceDetection/facedetection.cpp
+++ b/apps/FaceDetection/facedetection.cpp
@@ -83,7 +83,7 @@ public:
           NDN_LOG_DEBUG("Output Queue Size: " << output->size());
           iceflow::Block resultBlock;
           resultBlock.pushJson(jsonData);
-          pushFrame(resultBlock, face);
+          pushFrame(&resultBlock, face);
           auto end = std::chrono::system_clock::now();
           std::chrono::duration<double> elapsedTime = (end - start);
           NDN_LOG_INFO("Face Detection Compute Time: " << elapsedTime.count());

--- a/apps/ImageSource/imagesource.cpp
+++ b/apps/ImageSource/imagesource.cpp
@@ -71,7 +71,7 @@ public:
       result.second = grayFrame;
 
       resultBlock.pushJson(m_jsonOutput);
-      pushFrameCompress(resultBlock, grayFrame);
+      pushFrameCompress(&resultBlock, grayFrame);
       msCmp->setField(std::to_string(computeCounter), "CMP_FINISH", 0);
       // pass the frame and metaInfo to the producer Queue
 

--- a/apps/include/util.hpp
+++ b/apps/include/util.hpp
@@ -22,9 +22,9 @@
 #include "iceflow/block.hpp"
 #include "opencv2/opencv.hpp"
 
-void pushFrame(iceflow::Block block, cv::Mat frame);
+void pushFrame(iceflow::Block *block, cv::Mat frame);
 
-void pushFrameCompress(iceflow::Block block, cv::Mat frame);
+void pushFrameCompress(iceflow::Block *block, cv::Mat frame);
 
 cv::Mat pullFrame(iceflow::Block block);
 

--- a/apps/util/util.cpp
+++ b/apps/util/util.cpp
@@ -19,21 +19,21 @@
 #include "util.hpp"
 #include "iceflow/content-type-value.hpp"
 
-void pushFrame(iceflow::Block block, cv::Mat frame) {
+void pushFrame(iceflow::Block *block, cv::Mat frame) {
   std::vector<uchar> buffer;
   cv::imencode(".jpeg", frame, buffer);
   std::vector<uint8_t> &frameBuffer =
       reinterpret_cast<std::vector<uint8_t> &>(buffer);
-  block.pushSegmentManifestBlock(frameBuffer);
+  block->pushSegmentManifestBlock(frameBuffer);
 }
 
-void pushFrameCompress(iceflow::Block block, cv::Mat frame) {
+void pushFrameCompress(iceflow::Block *block, cv::Mat frame) {
   std::vector<uchar> buffer;
   std::vector<int> param(2);
   param[0] = cv::IMWRITE_JPEG_QUALITY;
   param[1] = 10; // default(95) 0-100
   cv::imencode(".jpeg", frame, buffer, param);
-  block.pushSegmentManifestBlock(buffer);
+  block->pushSegmentManifestBlock(buffer);
 }
 
 cv::Mat pullFrame(iceflow::Block block) {


### PR DESCRIPTION
In this PR, a fix is applied to a problem that was introduced during the refactoring of the `pushFrame` method/function (in #36). The problem is solved by passing the `Block` object by reference and not by value anymore.