### PR TITLE
refactor: use post-increment instead of pre-increment in for-loops

### DIFF
--- a/apps/FaceDetection/facedetection.cpp
+++ b/apps/FaceDetection/facedetection.cpp
@@ -74,7 +74,7 @@ public:
                         "IS->FD", 0);
         tie(frameFace, bboxes) = getFaceBox(faceNet, frameData, 0.7);
 
-        for (auto it = begin(bboxes); it != end(bboxes); ++it) {
+        for (auto it = begin(bboxes); it != end(bboxes); it++) {
           cv::Rect rec(it->at(0) - padding, it->at(1) - padding,
                        it->at(2) - it->at(0) + 2 * padding,
                        it->at(3) - it->at(1) + 2 * padding);

--- a/apps/PeopleCounter/peoplecounter.cpp
+++ b/apps/PeopleCounter/peoplecounter.cpp
@@ -153,7 +153,7 @@ void startProcessing(std::string &subSyncPrefix, std::vector<int> sub,
   threads.emplace_back(&iceflow::ConsumerTlv::runCon, simpleConsumer);
   threads.emplace_back(&fusion, &inputs, &totalInput, inputThreshold);
 
-  for (int i = 0; i < computeThreads; ++i) {
+  for (int i = 0; i < computeThreads; i++) {
     threads.emplace_back([&]() {
       compute->compute(&totalInput, &simpleProducer->outputQueueBlock,
                        outputThreshold);

--- a/include/iceflow/consumer-tlv.hpp
+++ b/include/iceflow/consumer-tlv.hpp
@@ -554,7 +554,7 @@ private:
 
   void sendInterestNew(int n) {
     auto timeout = m_timedoutInterests.begin();
-    for (int i = 0; i < n; ++i) {
+    for (int i = 0; i < n; i++) {
       // retransmissions first
       if (!m_timedoutInterests.empty()) {
         timeout->second++;


### PR DESCRIPTION
As it is more common to use the post-increment operator (`i++`) instead of the pre-increment operator (`++i`) in for-loop-statements and as both have the exact same effect in that context, this PR makes corresponding replacements to reduce the potential for confusion in the codebase.