### PR TITLE
ci: install ndn-cxx and libpsync on Ubuntu from APT repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,16 @@ on:
 jobs:
   build-ubuntu:
     runs-on: ubuntu-latest
-    container: ghcr.io/hsel-netsys/iceflow-ci-image:main
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run : |
+          echo "deb [arch=amd64 trusted=yes] https://nfd-nightly-apt.ndn.today/ubuntu jammy main" \
+          | sudo tee /etc/apt/sources.list.d/nfd-nightly.list
+          sudo apt update
+          sudo apt install libndn-cxx-dev libpsync-dev libyaml-cpp-dev libopencv-dev nlohmann-json3-dev cppcheck doxygen
 
       - name: Generate CMake Build Files
         run: cmake -DBUILD_TESTS=ON .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,6 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
-    needs: build-ubuntu
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
As I noticed that there is a APT repository with nightly builds of NDN packages for a number of Debian-based Linux distributions created by yoursunny, this PR incorporates an installation of `ndn-cxx` and `libpsync` from this repository into the CI.

Since the build on Ubuntu now takes a bit longer, I removed it as a dependency of the macOS job to make up for the lost time. Since the build on Ubuntu should fail early in case of any issues and thus cancel the whole workflow run, removing the dependency should be fine.

Lastly, as the repository also includes packages for Raspberry Pi, we should be able to integrate them into our test setup there.