### PR TITLE
docs: use top-level README.md for Doxygen index.html

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1154,7 +1154,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = README.md
+USE_MDFILE_AS_MAINPAGE = ./README.md
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common


### PR DESCRIPTION
Should fix #48 by explicitly pointing to the top-level `README.md` file in the `Doxyfile` for the documentation main page.