### PR TITLE
feat!: rework consumer and producer creation

### DIFF
--- a/examples/wordCount/wordcount/wordcount.cpp
+++ b/examples/wordCount/wordcount/wordcount.cpp
@@ -1,3 +1,4 @@
+#include "iceflow/consumer.hpp"
 #include "iceflow/iceflow.hpp"
 #include "iceflow/measurements.hpp"
 
@@ -64,11 +65,12 @@ void run(const std::string &syncPrefix, const std::string &nodePrefix,
   WordCounter compute;
   ndn::Face face;
 
-  iceflow::IceFlow consumer(syncPrefix, nodePrefix, std::optional(subTopic),
-                            std::nullopt, topicPartitions, face, std::nullopt);
+  auto iceflow =
+      std::make_shared<iceflow::IceFlow>(syncPrefix, nodePrefix, face);
+  auto consumer = iceflow::IceflowConsumer(iceflow, subTopic, topicPartitions);
 
   std::vector<std::thread> threads;
-  threads.emplace_back(&iceflow::IceFlow::run, &consumer);
+  threads.emplace_back(&iceflow::IceFlow::run, iceflow);
   threads.emplace_back([&compute, &consumer]() {
     compute.countWord([&consumer]() -> std::string {
       auto data = consumer.receiveData();

--- a/flake.lock
+++ b/flake.lock
@@ -3,19 +3,25 @@
     "cachix": {
       "inputs": {
         "devenv": "devenv_2",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
         "nixpkgs": [
           "devenv",
           "nixpkgs"
         ],
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": [
+          "devenv",
+          "pre-commit-hooks"
+        ]
       },
       "locked": {
-        "lastModified": 1710475558,
-        "narHash": "sha256-egKrPCKjy/cE+NqCj4hg2fNX/NwLCf0bRDInraYXDgs=",
+        "lastModified": 1712055811,
+        "narHash": "sha256-7FcfMm5A/f02yyzuavJe06zLa9hcMHsagE28ADcmQvk=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "661bbb7f8b55722a0406456b15267b5426a3bda6",
+        "rev": "02e38da89851ec7fec3356a5c04bc8349cae0e30",
         "type": "github"
       },
       "original": {
@@ -27,19 +33,19 @@
     "devenv": {
       "inputs": {
         "cachix": "cachix",
-        "flake-compat": "flake-compat_4",
+        "flake-compat": "flake-compat_2",
         "nix": "nix_2",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "pre-commit-hooks": "pre-commit-hooks_2"
+        "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1712628569,
-        "narHash": "sha256-4UaUWs2CzmP0WZa+9CZ3or8JqyAu/7G9GKNQdX8rx0E=",
+        "lastModified": 1713968789,
+        "narHash": "sha256-Gue8iwW3ZtCQs3EZKhk/i0uLaoUDfW1dpnaZ67MH64o=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "808caa6a89779c1b22bcae57d16d803bde1f631d",
+        "rev": "b26b52a4dac68bdc305f6b9df948c97f49b2c3ee",
         "type": "github"
       },
       "original": {
@@ -111,54 +117,6 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -182,24 +140,6 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
         "lastModified": 1710146030,
         "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
@@ -214,29 +154,6 @@
       }
     },
     "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1703887061,
-        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
       "inputs": {
         "nixpkgs": [
           "devenv",
@@ -270,11 +187,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1708577783,
-        "narHash": "sha256-92xq7eXlxIT5zFNccLpjiP7sdQqQI30Gyui2p/PfKZM=",
+        "lastModified": 1712911606,
+        "narHash": "sha256-BGvBhepCufsjcUkXnEEXhEVjwdJAwPglCC2+bInc794=",
         "owner": "domenkozar",
         "repo": "nix",
-        "rev": "ecd0af0c1f56de32cbad14daa1d82a132bf298f8",
+        "rev": "b24a9318ea3f3600c1e24b4a00691ee912d4de12",
         "type": "github"
       },
       "original": {
@@ -310,7 +227,10 @@
     },
     "nix_2": {
       "inputs": {
-        "flake-compat": "flake-compat_5",
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
         "nixpkgs": [
           "devenv",
           "nixpkgs"
@@ -318,11 +238,11 @@
         "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
-        "lastModified": 1710500156,
-        "narHash": "sha256-zvCqeUO2GLOm7jnU23G4EzTZR7eylcJN+HJ5svjmubI=",
+        "lastModified": 1712911606,
+        "narHash": "sha256-BGvBhepCufsjcUkXnEEXhEVjwdJAwPglCC2+bInc794=",
         "owner": "domenkozar",
         "repo": "nix",
-        "rev": "c5bbf14ecbd692eeabf4184cc8d50f79c2446549",
+        "rev": "b24a9318ea3f3600c1e24b4a00691ee912d4de12",
         "type": "github"
       },
       "original": {
@@ -382,22 +302,6 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1704874635,
-        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable_2": {
-      "locked": {
         "lastModified": 1710695816,
         "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
         "owner": "NixOS",
@@ -414,11 +318,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1712639375,
-        "narHash": "sha256-V/7wFmh6O1OGOrlk//CTW9q4lYpb/RB3p2tRQNws95U=",
+        "lastModified": 1714077598,
+        "narHash": "sha256-90m149E71nbusRcKIyjrmCoDFJxJwFVgyNQVfGaJ8Jg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73844014f48f8f968f98366b33bbdcf693d6d407",
+        "rev": "b96925eddcb6337b90b26651ebb00a10bd3f66c1",
         "type": "github"
       },
       "original": {
@@ -454,50 +358,24 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
         "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
         "nixpkgs": [
           "devenv",
-          "cachix",
           "nixpkgs"
         ],
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708018599,
-        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
+        "lastModified": 1713775815,
+        "narHash": "sha256-Wu9cdYTnGQQwtT20QQMg7jzkANKQjwBD9iccfGKkfls=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks_2": {
-      "inputs": {
-        "flake-compat": [
-          "devenv",
-          "flake-compat"
-        ],
-        "flake-utils": "flake-utils_3",
-        "gitignore": "gitignore_2",
-        "nixpkgs": [
-          "devenv",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable_2"
-      },
-      "locked": {
-        "lastModified": 1712055707,
-        "narHash": "sha256-4XLvuSIDZJGS17xEwSrNuJLL7UjDYKGJSbK1WWX2AK8=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "e35aed5fda3cc79f88ed7f1795021e559582093a",
+        "rev": "2ac4dcbf55ed43f3be0bae15e181f08a57af24a4",
         "type": "github"
       },
       "original": {
@@ -510,7 +388,7 @@
       "inputs": {
         "devenv": "devenv",
         "nixpkgs": "nixpkgs_2",
-        "systems": "systems_4"
+        "systems": "systems_3"
       }
     },
     "systems": {
@@ -544,21 +422,6 @@
       }
     },
     "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -6,6 +6,8 @@ set(ICEFLOW_INTERFACE_FILES
     iceflow/block.hpp
     iceflow/constants.hpp
     iceflow/iceflow.hpp
+    iceflow/producer.hpp
+    iceflow/consumer.hpp
     iceflow/content-type-value.hpp
     iceflow/data.hpp
     iceflow/logger.hpp

--- a/include/iceflow/consumer.hpp
+++ b/include/iceflow/consumer.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ICEFLOW_CONSUMER_HPP
+#define ICEFLOW_CONSUMER_HPP
+
+#include "iceflow.hpp"
+
+namespace iceflow {
+
+/**
+ * Allows for subscribing to data published by `IceflowProducer`s.
+ */
+class IceflowConsumer {
+
+public:
+  IceflowConsumer(std::shared_ptr<IceFlow> iceflow, const std::string &subTopic,
+                  const std::vector<int> &topicPartitions)
+      : m_iceflow(iceflow), m_subTopic(subTopic),
+        m_topicPartitions(topicPartitions) {
+
+    for (auto topicPartition : m_topicPartitions) {
+      auto subscriptionHandle = subscribeToTopicPartition(topicPartition);
+      m_subscriptionHandles.push_back(subscriptionHandle);
+    }
+  }
+
+  ~IceflowConsumer() { unsubscribeFromAllPartitions(); }
+
+  std::vector<uint8_t> receiveData() { return m_inputQueue.waitAndPopValue(); }
+
+private:
+  uint32_t subscribeToTopicPartition(int topicPartition) {
+    if (auto validIceflow = m_iceflow.lock()) {
+
+      std::function<void(std::vector<uint8_t>)> pushDataCallback =
+          std::bind(&RingBuffer<std::vector<uint8_t>>::push, &m_inputQueue,
+                    std::placeholders::_1);
+
+      return validIceflow->subscribeToTopicPartition(m_subTopic, topicPartition,
+                                                     pushDataCallback);
+    } else {
+      throw std::runtime_error("Iceflow instance has already expired.");
+    }
+  }
+
+  void unsubscribeFromAllPartitions() {
+    if (auto validIceflow = m_iceflow.lock()) {
+      for (auto subscriptionHandle : m_subscriptionHandles) {
+        validIceflow->unsubscribe(subscriptionHandle);
+      }
+    }
+  }
+
+private:
+  const std::weak_ptr<IceFlow> m_iceflow;
+  const std::string m_subTopic;
+
+  const std::vector<int> m_topicPartitions;
+  std::vector<uint32_t> m_subscriptionHandles;
+
+  RingBuffer<std::vector<uint8_t>> m_inputQueue;
+};
+} // namespace iceflow
+
+#endif // ICEFLOW_CONSUMER_HPP

--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ICEFLOW_PRODUCER_HPP
+#define ICEFLOW_PRODUCER_HPP
+
+#include "iceflow.hpp"
+
+namespace iceflow {
+
+/**
+ * Allows for publishing data to `IceflowConsumer`s.
+ *
+ * The data is split across one or more `topicPartitions` whose indexes can be
+ * passed as a constructor argument.
+ */
+class IceflowProducer {
+public:
+  IceflowProducer(std::shared_ptr<IceFlow> iceflow, const std::string &pubTopic,
+                  const std::vector<int> &topicPartitions,
+                  std::chrono::milliseconds publishInterval)
+      : m_iceflow(iceflow), m_pubTopic(pubTopic),
+        m_topicPartitions(topicPartitions), m_publishInterval(publishInterval),
+        m_lastPublishTimePoint(std::chrono::steady_clock::now()) {
+
+    if (auto validIceflow = m_iceflow.lock()) {
+      std::function<QueueEntry(void)> popQueueValueCallback =
+          std::bind(&IceflowProducer::popQueueValue, this);
+      std::function<bool(void)> hasQueueValueCallback =
+          std::bind(&IceflowProducer::hasQueueValue, this);
+      std::function<std::chrono::time_point<std::chrono::steady_clock>(void)>
+          getNextPublishTimePointCallback =
+              std::bind(&IceflowProducer::getNextPublishTimePoint, this);
+      std::function<void(void)> resetLastPublishTimepointCallback =
+          std::bind(&IceflowProducer::resetLastPublishTimePoint, this);
+
+      ProducerRegistrationInfo producerRegistration = {
+          popQueueValueCallback,
+          hasQueueValueCallback,
+          getNextPublishTimePointCallback,
+          resetLastPublishTimepointCallback,
+      };
+
+      m_subscriberId = validIceflow->registerProducer(producerRegistration);
+    } else {
+      throw std::runtime_error("Iceflow instance has already expired.");
+    }
+  }
+
+  ~IceflowProducer() {
+    if (auto validIceflow = m_iceflow.lock()) {
+      validIceflow->deregisterProducer(m_subscriberId);
+    }
+  }
+
+  void pushData(const std::vector<uint8_t> &data) { m_outputQueue.push(data); }
+
+private:
+  QueueEntry popQueueValue() {
+    int partitionIndex = m_partitionCount++ % m_topicPartitions.size();
+    auto partitionNumber = m_topicPartitions[partitionIndex];
+    auto data = m_outputQueue.waitAndPopValue();
+    m_lastPublishTimePoint = std::chrono::steady_clock::now();
+
+    return {
+        m_pubTopic,
+        partitionNumber,
+        data,
+    };
+  };
+
+  std::chrono::nanoseconds getTimeUntilNextPublish() {
+    auto elapsedTime =
+        std::chrono::steady_clock::now() - m_lastPublishTimePoint;
+
+    return m_publishInterval - elapsedTime;
+  }
+
+  bool hasQueueValue() { return !m_outputQueue.empty(); }
+
+  void resetLastPublishTimePoint() {
+    m_lastPublishTimePoint = std::chrono::steady_clock::now();
+  }
+
+  std::chrono::time_point<std::chrono::steady_clock> getNextPublishTimePoint() {
+    return m_lastPublishTimePoint + m_publishInterval;
+  }
+
+private:
+  const std::weak_ptr<IceFlow> m_iceflow;
+  const std::string m_pubTopic;
+  RingBuffer<std::vector<uint8_t>> m_outputQueue;
+
+  const std::vector<int> m_topicPartitions;
+  int m_partitionCount = 0;
+  std::chrono::nanoseconds m_publishInterval;
+  std::chrono::time_point<std::chrono::steady_clock> m_lastPublishTimePoint;
+
+  uint64_t m_subscriberId;
+}; // namespace iceflow
+} // namespace iceflow
+
+#endif // ICEFLOW_PRODUCER_HPP


### PR DESCRIPTION
This PR introduces three subclasses to fulfill the roles of consumer, producer, and a combined consumer/producer ("prosumer"). They inherit from the common `IceFlow` base class, which is turned abstract now in the sense that both its constructor and the methods for pushing and receiving data are now labelled as protected.

I think the general concept should point into the right direction, however, we might need to discuss the details a bit more when we meet the next time. After we resolved this discussion, we can think about a more dynamic way of subscribing and publishing to topics, as well as an API to modify the number of partitions at runtime.