### PR TITLE
chore: define suppression rules for cppcheck

### DIFF
--- a/.linter-suppressions
+++ b/.linter-suppressions
@@ -1,0 +1,5 @@
+// This file contains suppressions for cppcheck.
+
+missingIncludeSystem // Suppress system include errors
+missingInclude // Suppress other include errors
+unusedFunction // Suppress warnings about unused functions

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -20,4 +20,6 @@
 include("cmake/sources.cmake")
 
 add_custom_target(lint)
-add_custom_command(TARGET lint COMMAND cppcheck --enable=all ${ALL_SOURCES})
+add_custom_command(
+  TARGET lint COMMAND cppcheck --suppressions-list=.linter-suppressions
+                      --enable=all ${ALL_SOURCES})


### PR DESCRIPTION
This PR adds two suppression rules (`missingIncludeSystem` and `unusedFunction`) for `cppcheck` in order to make using the linting step a bit more useful. As `make lint` probably won't report false positives anymore, we could consider letting the linting CI step fail (after fixing the remaining minor issues) if there are any warnings emitted.