### PR TITLE
feat(producer.hpp): make `publishInterval` configurable at runtime

### DIFF
--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -38,6 +38,10 @@ public:
         m_topicPartitions(topicPartitions), m_publishInterval(publishInterval),
         m_lastPublishTimePoint(std::chrono::steady_clock::now()) {
 
+    if (publishInterval.count() < 0) {
+      throw std::invalid_argument("Publish interval has to be positive.");
+    }
+
     if (auto validIceflow = m_iceflow.lock()) {
       std::function<QueueEntry(void)> popQueueValueCallback =
           std::bind(&IceflowProducer::popQueueValue, this);

--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -38,9 +38,7 @@ public:
         m_topicPartitions(topicPartitions), m_publishInterval(publishInterval),
         m_lastPublishTimePoint(std::chrono::steady_clock::now()) {
 
-    if (publishInterval.count() < 0) {
-      throw std::invalid_argument("Publish interval has to be positive.");
-    }
+    checkPublishInterval(publishInterval);
 
     if (auto validIceflow = m_iceflow.lock()) {
       std::function<QueueEntry(void)> popQueueValueCallback =
@@ -75,14 +73,18 @@ public:
   void pushData(const std::vector<uint8_t> &data) { m_outputQueue.push(data); }
 
   void setPublishInterval(std::chrono::milliseconds publishInterval) {
-    if (publishInterval.count() < 0) {
-      throw std::invalid_argument("Publish interval has to be positive.");
-    }
+    checkPublishInterval(publishInterval);
 
     m_publishInterval = publishInterval;
   }
 
 private:
+  void checkPublishInterval(std::chrono::milliseconds publishInterval) {
+    if (publishInterval.count() < 0) {
+      throw std::invalid_argument("Publish interval has to be positive.");
+    }
+  }
+
   QueueEntry popQueueValue() {
     int partitionIndex = m_partitionCount++ % m_topicPartitions.size();
     auto partitionNumber = m_topicPartitions[partitionIndex];

--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -70,6 +70,14 @@ public:
 
   void pushData(const std::vector<uint8_t> &data) { m_outputQueue.push(data); }
 
+  void setPublishInterval(std::chrono::milliseconds publishInterval) {
+    if (publishInterval.count() < 0) {
+      throw std::invalid_argument("Publish interval has to be positive.");
+    }
+
+    m_publishInterval = publishInterval;
+  }
+
 private:
   QueueEntry popQueueValue() {
     int partitionIndex = m_partitionCount++ % m_topicPartitions.size();


### PR DESCRIPTION
When running an `IceflowProducer`, it might be desirable to be able to configure its `publishInterval` at runtime. This PR adds a corresponding setter as well as a check to the constructor to ensure that the time value that is being passed is always positive.