### PR TITLE
feat: make `topicPartitions` configurable at runtime

### DIFF
--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -39,6 +39,7 @@ public:
         m_lastPublishTimePoint(std::chrono::steady_clock::now()) {
 
     checkPublishInterval(publishInterval);
+    checkTopicPartitions(topicPartitions);
 
     if (auto validIceflow = m_iceflow.lock()) {
       std::function<QueueEntry(void)> popQueueValueCallback =

--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -78,10 +78,22 @@ public:
     m_publishInterval = publishInterval;
   }
 
+  void setTopicPartitions(const std::vector<int> &topicPartitions) {
+    checkTopicPartitions(topicPartitions);
+    m_topicPartitions = topicPartitions;
+  }
+
 private:
   void checkPublishInterval(std::chrono::milliseconds publishInterval) {
     if (publishInterval.count() < 0) {
       throw std::invalid_argument("Publish interval has to be positive.");
+    }
+  }
+
+  void checkTopicPartitions(const std::vector<int> &topicPartitions) {
+    if (topicPartitions.empty()) {
+      throw std::invalid_argument(
+          "At least one topic partition has to be defined!");
     }
   }
 
@@ -113,7 +125,7 @@ private:
   const std::string m_pubTopic;
   RingBuffer<std::vector<uint8_t>> m_outputQueue;
 
-  const std::vector<int> m_topicPartitions;
+  std::vector<int> m_topicPartitions;
   int m_partitionCount = 0;
   std::chrono::nanoseconds m_publishInterval;
   std::chrono::time_point<std::chrono::steady_clock> m_lastPublishTimePoint;


### PR DESCRIPTION
This PR applies changes similar to #54 to both the consumer and the producer class, only with regard to the `topicPartitions`. In this case, both the setter and the constructor perform a check to ensure that the partition vector is not empty.

There is currently some code duplication present which is not really desirable, I wasn't entirely sure about the best approach to avoid it at the moment. I suppose we could move the method that performs the check to a `util.hpp` or even the `iceflow.hpp` file – do you think that would make sense here, or is the amount of duplication tolerable? 