### PR TITLE
chore: remove obsolete namespace comment

### DIFF
--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -119,7 +119,7 @@ private:
   std::chrono::time_point<std::chrono::steady_clock> m_lastPublishTimePoint;
 
   uint64_t m_subscriberId;
-}; // namespace iceflow
+};
 } // namespace iceflow
 
 #endif // ICEFLOW_PRODUCER_HPP


### PR DESCRIPTION
Just noticed that there is doubled closing namespace comment in file of the producer class. This PR applies a simple fix for that.