### PR TITLE
feat!: use `uint64_t` instead of `int` for partition numbers

### DIFF
--- a/examples/wordCount/lines2words/lines2words.cpp
+++ b/examples/wordCount/lines2words/lines2words.cpp
@@ -44,7 +44,7 @@ public:
 
 void run(const std::string &syncPrefix, const std::string &nodePrefix,
          const std::string &subTopic, const std::string &pubTopic,
-         const std::vector<int> &topicPartitions,
+         const std::vector<uint64_t> &topicPartitions,
          std::chrono::milliseconds publishInterval) {
   WordSplitter wordSplitter;
   ndn::Face face;
@@ -92,7 +92,8 @@ int main(int argc, const char *argv[]) {
 
   std::string syncPrefix = config["syncPrefix"].as<std::string>();
   std::string nodePrefix = config["nodePrefix"].as<std::string>();
-  std::vector<int> partitions = config["partitions"].as<std::vector<int>>();
+  std::vector<uint64_t> partitions =
+      config["partitions"].as<std::vector<uint64_t>>();
   std::string pubTopic = producerConfig["topic"].as<std::string>();
   std::string subTopic = consumerConfig["topic"].as<std::string>();
   int publishInterval = producerConfig["publishInterval"].as<int>();

--- a/examples/wordCount/text2lines/text2lines.cpp
+++ b/examples/wordCount/text2lines/text2lines.cpp
@@ -53,7 +53,7 @@ public:
 };
 
 void run(const std::string &syncPrefix, const std::string &nodePrefix,
-         const std::string &pubTopic, std::vector<int> &topicPartitions,
+         const std::string &pubTopic, std::vector<uint64_t> &topicPartitions,
          const std::string &filename,
          std::chrono::milliseconds publishInterval) {
   std::cout << "Starting IceFlow Stream Processing - - - -" << std::endl;
@@ -100,7 +100,7 @@ int main(int argc, const char *argv[]) {
 
   auto syncPrefix = config["syncPrefix"].as<std::string>();
   auto nodePrefix = config["nodePrefix"].as<std::string>();
-  auto partitions = config["partitions"].as<std::vector<int>>();
+  auto partitions = config["partitions"].as<std::vector<uint64_t>>();
   auto pubTopic = producerConfig["topic"].as<std::string>();
   int publishInterval = producerConfig["publishInterval"].as<int>();
   int saveInterval = measurementConfig["saveInterval"].as<int>();

--- a/examples/wordCount/wordcount/wordcount.cpp
+++ b/examples/wordCount/wordcount/wordcount.cpp
@@ -61,7 +61,8 @@ private:
 };
 
 void run(const std::string &syncPrefix, const std::string &nodePrefix,
-         const std::string &subTopic, const std::vector<int> &topicPartitions) {
+         const std::string &subTopic,
+         const std::vector<uint64_t> &topicPartitions) {
   WordCounter compute;
   ndn::Face face;
 
@@ -101,7 +102,8 @@ int main(int argc, const char *argv[]) {
 
   std::string syncPrefix = config["syncPrefix"].as<std::string>();
   std::string nodePrefix = config["nodePrefix"].as<std::string>();
-  std::vector<int> partitions = config["partitions"].as<std::vector<int>>();
+  std::vector<uint64_t> partitions =
+      config["partitions"].as<std::vector<uint64_t>>();
   std::string subTopic = consumerConfig["topic"].as<std::string>();
 
   int saveInterval = measurementConfig["saveInterval"].as<int>();

--- a/include/iceflow/consumer.hpp
+++ b/include/iceflow/consumer.hpp
@@ -33,7 +33,7 @@ class IceflowConsumer {
 public:
   IceflowConsumer(std::shared_ptr<IceFlow> iceflow, const std::string &subTopic,
                   // TODO: Change constructor parameter to std::set as well.
-                  const std::vector<int> &topicPartitions)
+                  const std::vector<uint64_t> &topicPartitions)
       : m_iceflow(iceflow), m_subTopic(subTopic)
 
   {
@@ -45,15 +45,15 @@ public:
 
   std::vector<uint8_t> receiveData() { return m_inputQueue.waitAndPopValue(); }
 
-  void setTopicPartitions(const std::vector<int> &topicPartitions) {
+  void setTopicPartitions(const std::vector<uint64_t> &topicPartitions) {
     if (topicPartitions.empty()) {
       throw std::invalid_argument(
           "At least one topic partition has to be defined!");
     }
 
     if (auto validIceflow = m_iceflow.lock()) {
-      std::unordered_set<int> topicPartitionSet(topicPartitions.begin(),
-                                                topicPartitions.end());
+      std::unordered_set<uint64_t> topicPartitionSet(topicPartitions.begin(),
+                                                     topicPartitions.end());
 
       std::vector<decltype(m_subscriptionHandles)::key_type> handlesToErase;
       for (auto subscriptionHandle : m_subscriptionHandles) {
@@ -81,7 +81,7 @@ public:
   }
 
 private:
-  uint32_t subscribeToTopicPartition(int topicPartition) {
+  uint32_t subscribeToTopicPartition(uint64_t topicPartition) {
     if (auto validIceflow = m_iceflow.lock()) {
 
       std::function<void(std::vector<uint8_t>)> pushDataCallback =
@@ -108,7 +108,7 @@ private:
   const std::weak_ptr<IceFlow> m_iceflow;
   const std::string m_subTopic;
 
-  std::unordered_map<int, uint32_t> m_subscriptionHandles;
+  std::unordered_map<uint64_t, uint32_t> m_subscriptionHandles;
 
   RingBuffer<std::vector<uint8_t>> m_inputQueue;
 };

--- a/include/iceflow/iceflow.hpp
+++ b/include/iceflow/iceflow.hpp
@@ -36,7 +36,7 @@ namespace iceflow {
 
 struct QueueEntry {
   std::string topic;
-  int partitionNumber;
+  uint64_t partitionNumber;
   std::vector<uint8_t> data;
 };
 
@@ -143,7 +143,7 @@ public:
 
 private:
   uint32_t subscribeToTopicPartition(
-      const std::string &topic, int partitionNumber,
+      const std::string &topic, uint64_t partitionNumber,
       std::function<void(std::vector<uint8_t>)> &pushDataCallback) {
 
     auto subscribedTopic = ndn::Name(topic).appendNumber(partitionNumber);
@@ -178,12 +178,13 @@ private:
     // TODO: Implement if needed
   }
 
-  ndn::Name prepareDataName(const std::string &topic, int partitionNumber) {
+  ndn::Name prepareDataName(const std::string &topic,
+                            uint64_t partitionNumber) {
     return ndn::Name(topic).appendNumber(partitionNumber);
   }
 
   void publishMsg(std::vector<uint8_t> payload, const std::string &topic,
-                  int partitionNumber) {
+                  uint64_t partitionNumber) {
     auto dataID = prepareDataName(topic, partitionNumber);
     auto sequenceNo = m_svsPubSub->publish(
         dataID, payload, ndn::Name(m_nodePrefix), ndn::time::seconds(4));

--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -32,7 +32,7 @@ namespace iceflow {
 class IceflowProducer {
 public:
   IceflowProducer(std::shared_ptr<IceFlow> iceflow, const std::string &pubTopic,
-                  const std::vector<int> &topicPartitions,
+                  const std::vector<uint64_t> &topicPartitions,
                   std::chrono::milliseconds publishInterval)
       : m_iceflow(iceflow), m_pubTopic(pubTopic),
         m_topicPartitions(topicPartitions), m_publishInterval(publishInterval),
@@ -79,7 +79,7 @@ public:
     m_publishInterval = publishInterval;
   }
 
-  void setTopicPartitions(const std::vector<int> &topicPartitions) {
+  void setTopicPartitions(const std::vector<uint64_t> &topicPartitions) {
     checkTopicPartitions(topicPartitions);
     m_topicPartitions = topicPartitions;
   }
@@ -91,7 +91,7 @@ private:
     }
   }
 
-  void checkTopicPartitions(const std::vector<int> &topicPartitions) {
+  void checkTopicPartitions(const std::vector<uint64_t> &topicPartitions) {
     if (topicPartitions.empty()) {
       throw std::invalid_argument(
           "At least one topic partition has to be defined!");
@@ -100,7 +100,7 @@ private:
 
   QueueEntry popQueueValue() {
     int partitionIndex = m_partitionCount++ % m_topicPartitions.size();
-    auto partitionNumber = m_topicPartitions[partitionIndex];
+    uint64_t partitionNumber = m_topicPartitions[partitionIndex];
     auto data = m_outputQueue.waitAndPopValue();
     m_lastPublishTimePoint = std::chrono::steady_clock::now();
 
@@ -126,7 +126,7 @@ private:
   const std::string m_pubTopic;
   RingBuffer<std::vector<uint8_t>> m_outputQueue;
 
-  std::vector<int> m_topicPartitions;
+  std::vector<uint64_t> m_topicPartitions;
   int m_partitionCount = 0;
   std::chrono::nanoseconds m_publishInterval;
   std::chrono::time_point<std::chrono::steady_clock> m_lastPublishTimePoint;


### PR DESCRIPTION
In the context of #56, I got the impression that it doesn't really make sense to use `int` as a datatype for the partition numbers as they should probably always be positive. Therefore, this PR proposes changing the datatype to `uint64_t`, which also aligns it with the datatype used by `ndn-cxx` for creating/appending numeric name components (via the `appendNumber`method).

As a next step (in a follow-up PR), I would change the data structure used for the partition numbers from an `std::vector` to an `std::unordered_set` in order to ensure that a partition number cannot be used twice.