### PR TITLE
fix: better enforce positive publish intervals 

### DIFF
--- a/examples/wordCount/lines2words/lines2words.cpp
+++ b/examples/wordCount/lines2words/lines2words.cpp
@@ -96,7 +96,7 @@ int main(int argc, const char *argv[]) {
       config["partitions"].as<std::vector<uint64_t>>();
   std::string pubTopic = producerConfig["topic"].as<std::string>();
   std::string subTopic = consumerConfig["topic"].as<std::string>();
-  int publishInterval = producerConfig["publishInterval"].as<int>();
+  uint64_t publishInterval = producerConfig["publishInterval"].as<uint64_t>();
   uint64_t saveThreshold = measurementConfig["saveThreshold"].as<uint64_t>();
 
   ::signal(SIGINT, signalCallbackHandler);

--- a/examples/wordCount/text2lines/text2lines.cpp
+++ b/examples/wordCount/text2lines/text2lines.cpp
@@ -103,7 +103,7 @@ int main(int argc, const char *argv[]) {
   auto nodePrefix = config["nodePrefix"].as<std::string>();
   auto partitions = config["partitions"].as<std::vector<uint64_t>>();
   auto pubTopic = producerConfig["topic"].as<std::string>();
-  int publishInterval = producerConfig["publishInterval"].as<int>();
+  uint64_t publishInterval = producerConfig["publishInterval"].as<uint64_t>();
   uint64_t saveThreshold = measurementConfig["saveThreshold"].as<uint64_t>();
 
   ::signal(SIGINT, signalCallbackHandler);

--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -37,10 +37,10 @@ public:
                   const std::unordered_set<uint64_t> &topicPartitions,
                   std::chrono::milliseconds publishInterval)
       : m_iceflow(iceflow), m_pubTopic(pubTopic),
-        m_topicPartitions(topicPartitions), m_publishInterval(publishInterval),
+        m_topicPartitions(topicPartitions),
         m_lastPublishTimePoint(std::chrono::steady_clock::now()) {
 
-    checkPublishInterval(publishInterval);
+    setPublishInterval(publishInterval);
     setTopicPartitions(topicPartitions);
 
     if (auto validIceflow = m_iceflow.lock()) {
@@ -76,7 +76,9 @@ public:
   void pushData(const std::vector<uint8_t> &data) { m_outputQueue.push(data); }
 
   void setPublishInterval(std::chrono::milliseconds publishInterval) {
-    checkPublishInterval(publishInterval);
+    if (publishInterval.count() < 0) {
+      throw std::invalid_argument("Publish interval has to be positive.");
+    }
 
     m_publishInterval = publishInterval;
   }
@@ -88,12 +90,6 @@ public:
   }
 
 private:
-  void checkPublishInterval(std::chrono::milliseconds publishInterval) {
-    if (publishInterval.count() < 0) {
-      throw std::invalid_argument("Publish interval has to be positive.");
-    }
-  }
-
   void
   checkTopicPartitions(const std::unordered_set<uint64_t> &topicPartitions) {
     if (topicPartitions.empty()) {


### PR DESCRIPTION
This PR adds a couple of additional small changes regarding the handling of the `publishInterval`, enforcing positive values already for the config files. In the `IceflowProducer` class itself, the check for positive values is slightly refactored.