### PR TITLE
fix: improve handling of measurements

### DIFF
--- a/examples/wordCount/lines2words/lines2words.cpp
+++ b/examples/wordCount/lines2words/lines2words.cpp
@@ -97,11 +97,11 @@ int main(int argc, const char *argv[]) {
   std::string pubTopic = producerConfig["topic"].as<std::string>();
   std::string subTopic = consumerConfig["topic"].as<std::string>();
   int publishInterval = producerConfig["publishInterval"].as<int>();
-  int saveInterval = measurementConfig["saveInterval"].as<int>();
+  int saveThreshold = measurementConfig["saveThreshold"].as<int>();
 
   ::signal(SIGINT, signalCallbackHandler);
   measurementHandler = new iceflow::Measurement(measurementFileName, nodePrefix,
-                                                saveInterval, "A");
+                                                saveThreshold, "A");
 
   try {
     run(syncPrefix, nodePrefix, subTopic, pubTopic,

--- a/examples/wordCount/lines2words/lines2words.cpp
+++ b/examples/wordCount/lines2words/lines2words.cpp
@@ -97,7 +97,7 @@ int main(int argc, const char *argv[]) {
   std::string pubTopic = producerConfig["topic"].as<std::string>();
   std::string subTopic = consumerConfig["topic"].as<std::string>();
   int publishInterval = producerConfig["publishInterval"].as<int>();
-  int saveThreshold = measurementConfig["saveThreshold"].as<int>();
+  uint64_t saveThreshold = measurementConfig["saveThreshold"].as<uint64_t>();
 
   ::signal(SIGINT, signalCallbackHandler);
   measurementHandler = new iceflow::Measurement(measurementFileName, nodePrefix,

--- a/examples/wordCount/lines2words/lines2words1.yaml
+++ b/examples/wordCount/lines2words/lines2words1.yaml
@@ -11,4 +11,4 @@ producer:
   publishInterval: 500
 
 measurements:
-  saveInterval: 100
+  saveThreshold: 100

--- a/examples/wordCount/lines2words/lines2words2.yaml
+++ b/examples/wordCount/lines2words/lines2words2.yaml
@@ -11,4 +11,4 @@ producer:
   publishInterval: 500
 
 measurements:
-  saveInterval: 100
+  saveThreshold: 100

--- a/examples/wordCount/text2lines/text2lines.cpp
+++ b/examples/wordCount/text2lines/text2lines.cpp
@@ -104,11 +104,11 @@ int main(int argc, const char *argv[]) {
   auto partitions = config["partitions"].as<std::vector<uint64_t>>();
   auto pubTopic = producerConfig["topic"].as<std::string>();
   int publishInterval = producerConfig["publishInterval"].as<int>();
-  int saveInterval = measurementConfig["saveInterval"].as<int>();
+  int saveThreshold = measurementConfig["saveThreshold"].as<int>();
 
   ::signal(SIGINT, signalCallbackHandler);
   measurementHandler = new iceflow::Measurement(measurementFileName, nodePrefix,
-                                                saveInterval, "A");
+                                                saveThreshold, "A");
 
   try {
     run(syncPrefix, nodePrefix, pubTopic,

--- a/examples/wordCount/text2lines/text2lines.cpp
+++ b/examples/wordCount/text2lines/text2lines.cpp
@@ -104,7 +104,7 @@ int main(int argc, const char *argv[]) {
   auto partitions = config["partitions"].as<std::vector<uint64_t>>();
   auto pubTopic = producerConfig["topic"].as<std::string>();
   int publishInterval = producerConfig["publishInterval"].as<int>();
-  int saveThreshold = measurementConfig["saveThreshold"].as<int>();
+  uint64_t saveThreshold = measurementConfig["saveThreshold"].as<uint64_t>();
 
   ::signal(SIGINT, signalCallbackHandler);
   measurementHandler = new iceflow::Measurement(measurementFileName, nodePrefix,

--- a/examples/wordCount/text2lines/text2lines.yaml
+++ b/examples/wordCount/text2lines/text2lines.yaml
@@ -7,4 +7,4 @@ producer:
   publishInterval: 500
 
 measurements:
-  saveInterval: 100
+  saveThreshold: 100

--- a/examples/wordCount/wordcount/wordcount.cpp
+++ b/examples/wordCount/wordcount/wordcount.cpp
@@ -106,11 +106,11 @@ int main(int argc, const char *argv[]) {
       config["partitions"].as<std::vector<uint64_t>>();
   std::string subTopic = consumerConfig["topic"].as<std::string>();
 
-  int saveInterval = measurementConfig["saveInterval"].as<int>();
+  int saveThreshold = measurementConfig["saveThreshold"].as<int>();
 
   ::signal(SIGINT, signalCallbackHandler);
   measurementHandler = new iceflow::Measurement(measurementFileName, nodePrefix,
-                                                saveInterval, "A");
+                                                saveThreshold, "A");
 
   try {
     run(syncPrefix, nodePrefix, subTopic,

--- a/examples/wordCount/wordcount/wordcount.cpp
+++ b/examples/wordCount/wordcount/wordcount.cpp
@@ -106,7 +106,7 @@ int main(int argc, const char *argv[]) {
       config["partitions"].as<std::vector<uint64_t>>();
   std::string subTopic = consumerConfig["topic"].as<std::string>();
 
-  int saveThreshold = measurementConfig["saveThreshold"].as<int>();
+  uint64_t saveThreshold = measurementConfig["saveThreshold"].as<uint64_t>();
 
   ::signal(SIGINT, signalCallbackHandler);
   measurementHandler = new iceflow::Measurement(measurementFileName, nodePrefix,

--- a/examples/wordCount/wordcount/wordcount.yaml
+++ b/examples/wordCount/wordcount/wordcount.yaml
@@ -6,4 +6,4 @@ consumer:
   topic: /lines2words/dataMain
 
 measurements:
-  saveInterval: 100
+  saveThreshold: 100

--- a/include/iceflow/measurements.hpp
+++ b/include/iceflow/measurements.hpp
@@ -44,9 +44,6 @@ public:
       : m_observedObject(observedObject), m_nodeName(nodeName),
         m_measurementId(measurementId), m_saveThreshold(saveThreshold) {
     m_fileCount = 0;
-    m_lastSaveToFile = duration_cast<std::chrono::milliseconds>(
-                           std::chrono::system_clock::now().time_since_epoch())
-                           .count();
     createMeasurementFolder();
   }
   ~Measurement(){};
@@ -129,7 +126,6 @@ private:
   std::vector<Entry> m_entries;
   int m_saveThreshold;
   std::ofstream m_ofstream;
-  int m_lastSaveToFile;
 };
 
 } // namespace iceflow

--- a/include/iceflow/measurements.hpp
+++ b/include/iceflow/measurements.hpp
@@ -19,9 +19,11 @@
 #ifndef ICEFLOW_CORE_MEASUREMENTS_H
 #define ICEFLOW_CORE_MEASUREMENTS_H
 
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 #include "logger.hpp"
 

--- a/include/iceflow/measurements.hpp
+++ b/include/iceflow/measurements.hpp
@@ -40,9 +40,9 @@ struct Entry // represents an entry: #, entryname, timestamp
 class Measurement {
 public:
   Measurement(const std::string &measurementId, const std::string &nodeName,
-              int saveInterval, const std::string &observedObject)
+              int saveThreshold, const std::string &observedObject)
       : m_observedObject(observedObject), m_nodeName(nodeName),
-        m_measurementId(measurementId), m_saveInterval(saveInterval) {
+        m_measurementId(measurementId), m_saveThreshold(saveThreshold) {
     m_fileCount = 0;
     m_lastSaveToFile = duration_cast<std::chrono::milliseconds>(
                            std::chrono::system_clock::now().time_since_epoch())
@@ -87,7 +87,7 @@ public:
             .count();
     entry.timestamp = currentTimestamp;
     m_entries.push_back(entry);
-    if (m_entries.size() >= m_saveInterval) {
+    if (m_entries.size() >= m_saveThreshold) {
       recordToFile();
     }
   }
@@ -127,7 +127,7 @@ private:
   std::string m_observedObject;
   int m_fileCount;
   std::vector<Entry> m_entries;
-  int m_saveInterval;
+  int m_saveThreshold;
   std::ofstream m_ofstream;
   int m_lastSaveToFile;
 };

--- a/include/iceflow/measurements.hpp
+++ b/include/iceflow/measurements.hpp
@@ -40,7 +40,7 @@ struct Entry // represents an entry: #, entryname, timestamp
 class Measurement {
 public:
   Measurement(const std::string &measurementId, const std::string &nodeName,
-              int saveThreshold, const std::string &observedObject)
+              uint64_t saveThreshold, const std::string &observedObject)
       : m_observedObject(observedObject), m_nodeName(nodeName),
         m_measurementId(measurementId), m_saveThreshold(saveThreshold) {
     m_fileCount = 0;
@@ -124,7 +124,7 @@ private:
   std::string m_observedObject;
   int m_fileCount;
   std::vector<Entry> m_entries;
-  int m_saveThreshold;
+  uint64_t m_saveThreshold;
   std::ofstream m_ofstream;
 };
 

--- a/include/iceflow/measurements.hpp
+++ b/include/iceflow/measurements.hpp
@@ -75,7 +75,7 @@ public:
                   << interestName << " - " << entryName << "#################");
 
     uint64_t currentTimestamp =
-        duration_cast<std::chrono::milliseconds>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::system_clock::now().time_since_epoch())
             .count();
 

--- a/include/iceflow/measurements.hpp
+++ b/include/iceflow/measurements.hpp
@@ -27,14 +27,11 @@
 
 namespace iceflow {
 
-struct Entry // represents an entry: #, entryname, timestamp
-{
-  // string nodeName;
-  // string observedObject;
+struct Entry {
   std::string interest;
   std::string entryname;
   uint64_t timestamp;
-  unsigned short size;
+  uint64_t size;
 };
 
 class Measurement {
@@ -71,18 +68,22 @@ public:
   }
 
   void setField(const std::string &interestName, const std::string &entryName,
-                int dataSize) {
+                uint64_t dataSize) {
     NDN_LOG_DEBUG("################# SETTING FIELD "
                   << interestName << " - " << entryName << "#################");
-    Entry entry;
-    entry.interest = interestName;
-    entry.entryname = entryName;
-    entry.size = dataSize;
+
     uint64_t currentTimestamp =
         duration_cast<std::chrono::milliseconds>(
             std::chrono::system_clock::now().time_since_epoch())
             .count();
-    entry.timestamp = currentTimestamp;
+
+    Entry entry = {
+        interestName,
+        entryName,
+        currentTimestamp,
+        dataSize,
+    };
+
     m_entries.push_back(entry);
     if (m_entries.size() >= m_saveThreshold) {
       recordToFile();


### PR DESCRIPTION
This PR adds another round of smaller changes to improve the quality of the code and to make some parts of the code more understandable.

The most significant change is actually the renaming of the parameter `saveInterval` to `saveThreshold` to make it a bit clearer that this is not a time interval, but a threshold related to the number of measurement entries. Furthermore, similar to #60, the parameter is now being parsed as a `uint64_t`, enforcing a positive threshold.

In general, this area of the codebase requires some more work and better documentation. Also, some columns of the CSV files are not really being used at the moment (in particular, `interest` and `dataSize`) so we might need to discuss what we actually want to measure with this class and whether it should be part of the core IceFlow library.