### PR TITLE
ci: remove build artifact upload steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,18 +31,6 @@ jobs:
       - name: Run Tests
         run: nix develop --impure .#ci -c make test
 
-      - name: Export IceFlow Example Application Binaries
-        uses: actions/upload-artifact@v3
-        with:
-          name: ubuntu-binaries
-          path: |
-            build/agedetection
-            build/aggregate
-            build/facedetection
-            build/genderdetection
-            build/imagesource
-            build/peoplecounter
-
   build-macos:
     runs-on: macos-latest
 
@@ -65,15 +53,3 @@ jobs:
 
       - name: Run Tests
         run: nix develop --impure .#ci -c make test
-
-      - name: Export IceFlow Example Application Binaries
-        uses: actions/upload-artifact@v3
-        with:
-          name: macos-binaries
-          path: |
-            build/agedetection
-            build/aggregate
-            build/facedetection
-            build/genderdetection
-            build/imagesource
-            build/peoplecounter


### PR DESCRIPTION
I've noticed that the CI workflow currently still tries to upload build artifacts that are not created anymore. Therefore, this PR removes the corresponding lines from the `build.yaml` file.

We could, however, also consider exporting the new generated binaries, but I guess that does not have that much value considering that we have the docker images.