### PR TITLE
chore: remove Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM ghcr.io/hsel-netsys/iceflow-ci-image:main
-COPY . /
-RUN cmake . && \
-    make && \
-    make install
-
-ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
This PR removes the now obsolete `Dockerfile`, which has been become unnecessary after the switch to the new Nix-based approach (see #51).