### PR TITLE
chore: let lint target fail on warning

### DIFF
--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -22,4 +22,4 @@ include("cmake/sources.cmake")
 add_custom_target(lint)
 add_custom_command(
   TARGET lint COMMAND cppcheck --suppressions-list=.linter-suppressions
-                      --enable=all ${ALL_SOURCES})
+                      --enable=all ${ALL_SOURCES} --error-exitcode=2)

--- a/examples/wordCount/wordcount/wordcount.cpp
+++ b/examples/wordCount/wordcount/wordcount.cpp
@@ -33,10 +33,8 @@ public:
       std::string word;
       while (stream >> word) {
         std::cout << "Word occurrences:\n";
-        // Convert the word to lowercase to make the counting case-insensitive
-        for (char &c : word) {
-          c = std::tolower(c);
-        }
+        std::transform(word.begin(), word.end(), word.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
 
         // Increment the count for the word in the map
         wordCountMap[word]++;


### PR DESCRIPTION
This PR makes the linting step in the CI a bit stricter by letting `cppcheck` exit with an error code if a warning is emitted.

To let the CI actually pass, this PR also address the one warning that was still emitted by the linter regarding the use of loop instead of a transform algorithm for converting the words in the `wordCount` example to lowercase.