### PR TITLE
Fix and improve behavior of publication loop

### DIFF
--- a/include/iceflow/iceflow.hpp
+++ b/include/iceflow/iceflow.hpp
@@ -95,17 +95,15 @@ public:
 
     m_running = true;
     while (m_running) {
+      NDN_LOG_INFO("Checking if producers are registered...");
+      std::unique_lock lock(m_producerRegistrationMutex);
+      m_producerRegistrationConditionVariable.wait(
+          lock, [this] { return m_producersAvailable; });
+      NDN_LOG_INFO("At least one producer is registered, continuing "
+                   "publishing thread.");
+
       auto closestNextPublishTimePoint =
           std::chrono::time_point<std::chrono::steady_clock>::max();
-
-      {
-        NDN_LOG_INFO("Checking if producers are registered...");
-        std::unique_lock lock(m_producerRegistrationMutex);
-        m_producerRegistrationConditionVariable.wait(
-            lock, [this] { return m_producersAvailable; });
-        NDN_LOG_INFO("At least one producer is registered, continuing "
-                     "publishing thread.");
-      }
 
       for (auto producerRegistrationTuple : m_producerRegistrations) {
         auto producerRegistration = std::get<1>(producerRegistrationTuple);
@@ -203,16 +201,15 @@ private:
   }
 
   uint64_t registerProducer(ProducerRegistrationInfo producerRegistration) {
+    std::lock_guard lock(m_producerRegistrationMutex);
+
     uint64_t producerId = m_nextProducerId++;
     m_producerRegistrations.insert({producerId, producerRegistration});
 
     if (!m_producersAvailable) {
-      {
-        std::lock_guard lock(m_producerRegistrationMutex);
-        m_producersAvailable = true;
-        NDN_LOG_INFO(
-            "Producer has been registered, resuming producer procedure.");
-      }
+      m_producersAvailable = true;
+      NDN_LOG_INFO(
+          "Producer has been registered, resuming producer procedure.");
       m_producerRegistrationConditionVariable.notify_one();
     }
 
@@ -220,14 +217,12 @@ private:
   }
 
   void deregisterProducer(u_int64_t producerId) {
+    std::lock_guard lock(m_producerRegistrationMutex);
 
     m_producerRegistrations.erase(producerId);
 
     if (m_producerRegistrations.empty()) {
-      {
-        std::lock_guard lock(m_producerRegistrationMutex);
-        m_producersAvailable = false;
-      }
+      m_producersAvailable = false;
       m_producerRegistrationConditionVariable.notify_one();
     }
   }

--- a/include/iceflow/iceflow.hpp
+++ b/include/iceflow/iceflow.hpp
@@ -95,10 +95,8 @@ public:
 
     m_running = true;
     while (m_running) {
-      std::chrono::time_point<std::chrono::steady_clock>
-          closestNextPublishTimePoint;
-      // TODO: Get rid of this variable
-      bool timepointSet = false;
+      auto closestNextPublishTimePoint =
+          std::chrono::time_point<std::chrono::steady_clock>::max();
 
       {
         NDN_LOG_INFO("Checking if producers are registered...");
@@ -117,15 +115,11 @@ public:
         auto timeUntilNextPublish =
             nextPublishTimePoint - std::chrono::steady_clock::now();
 
-        auto publishTimerExpired = timeUntilNextPublish.count() < 0;
+        if (nextPublishTimePoint < closestNextPublishTimePoint) {
+          closestNextPublishTimePoint = nextPublishTimePoint;
+        }
 
-        if (!publishTimerExpired) {
-          if (!timepointSet ||
-              nextPublishTimePoint < closestNextPublishTimePoint) {
-            closestNextPublishTimePoint = nextPublishTimePoint;
-            timepointSet = true;
-          }
-
+        if (timeUntilNextPublish.count() > 0) {
           continue;
         }
 


### PR DESCRIPTION
This PR resolves one source TODO comment in the source code by getting rid of the helper variable `timepointSet` by introducing an `std::optional` instead.