### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/doc/Nix-Developer-Guide.md
+++ b/doc/Nix-Developer-Guide.md
@@ -122,7 +122,7 @@ You can use other package definitions already present in the `flake.nix` as temp
 
 For other build systems and more information regarding build system specific configuration, refer to the Nix documentation regarding [build hooks](https://nixos.org/manual/nixpkgs/stable/#chap-hooks).
 
-Some general information regarding C-based projects can also be found in the [NixOS Wiki](https://nixos.wiki/wiki/C).
+Some general information regarding C-based projects can also be found in the [NixOS Wiki](https://wiki.nixos.org/wiki/C).
 
 For more information regarding package definitions in general, refer to the Nix documentation regarding the [Standard environment](https://nixos.org/manual/nixpkgs/stable/#part-stdenv)
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️