### PR TITLE
feat: add synchronization mechanism for IceFlow consumers

### DIFF
--- a/include/iceflow/iceflow.hpp
+++ b/include/iceflow/iceflow.hpp
@@ -166,6 +166,13 @@ private:
     return subscriptionHandle;
   }
 
+  //   utint32_t subscribeToConsumerGroup(std::string consumerPrefix) {
+  //  auto subscriptionHandle = m_svsPubSub->subscribe(
+  //         subscribedTopic, std::bind(&IceFlow::subscribeCallBack, this,
+  //                                    pushDataCallback,
+  //                                    std::placeholders::_1));
+  //   }
+
   void unsubscribe(uint32_t subscriptionHandle) {
     m_svsPubSub->unsubscribe(subscriptionHandle);
   }


### PR DESCRIPTION
This PR will add an experimental synchronization and re-partitioning mechanism for IceFlow consumers, allowing them to adjust their partition sizes at runtime.

The changes in this PR are still in an early phase of development, and I am also not sure yet whether the approach I am going to take here actually makes that much sense. However, I already to open this PR to signal that I am working on this and to have a basis for potential discussions.