### PR TITLE
feat: add mechanism to trigger scaling via gRPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ set(CMAKE_CXX_STANDARD 20)
 
 find_package(Boost)
 find_package(PkgConfig)
+find_package(OpenSSL REQUIRED)
+find_package(gRPC CONFIG REQUIRED)
+message(STATUS "Using gRPC ${gRPC_VERSION}")
+find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
 pkg_check_modules(NDN_CXX REQUIRED libndn-cxx)
 pkg_check_modules(SVS REQUIRED libndn-svs)
 
@@ -32,12 +36,15 @@ include(cmake/lint.cmake)
 
 include(GNUInstallDirs)
 
+set(PROTO_BINARY_DIR ${CMAKE_BINARY_DIR}/build/generated)
+file(MAKE_DIRECTORY ${PROTO_BINARY_DIR})
+set(PROTO_IMPORT_DIRS proto/)
+
 set(SOURCE_FILES src/iceflow.cpp src/consumer.cpp src/producer.cpp
                  src/measurements.cpp)
 
-add_library(iceflow SHARED ${SOURCE_FILES})
+add_library(iceflow SHARED ${SOURCE_FILES} proto/iceflow.proto)
 
-target_include_directories(iceflow PUBLIC include/iceflow)
 target_compile_options(iceflow PRIVATE -D_GNU_SOURCE -DBOOST_LOG_DYN_LINK)
 target_link_libraries(
   iceflow
@@ -46,7 +53,9 @@ target_link_libraries(
   -lboost_system
   -lpthread
   -lndn-cxx
-  -lndn-svs)
+  -lndn-svs
+  OpenSSL::SSL
+  gRPC::grpc++)
 
 option(BUILD_APPS "Build IceFlow examples" ON)
 option(BUILD_TESTS "Build library tests" OFF)
@@ -61,6 +70,27 @@ if(BUILD_TESTS)
   add_subdirectory(tests)
   enable_testing()
 endif()
+
+protobuf_generate(TARGET iceflow IMPORT_DIRS ${PROTO_IMPORT_DIRS}
+                  PROTOC_OUT_DIR ${PROTO_BINARY_DIR})
+
+protobuf_generate(
+  TARGET
+  iceflow
+  LANGUAGE
+  grpc
+  GENERATE_EXTENSIONS
+  .grpc.pb.h
+  .grpc.pb.cc
+  PLUGIN
+  protoc-gen-grpc=\$<TARGET_FILE:gRPC::grpc_cpp_plugin>
+  IMPORT_DIRS
+  ${PROTO_IMPORT_DIRS}
+  PROTOC_OUT_DIR
+  ${PROTO_BINARY_DIR})
+
+target_include_directories(
+  iceflow PUBLIC include/iceflow "$<BUILD_INTERFACE:${PROTO_BINARY_DIR}>")
 
 install(TARGETS iceflow DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY include/iceflow DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,9 @@ set(PROTO_BINARY_DIR ${CMAKE_BINARY_DIR}/build/generated)
 file(MAKE_DIRECTORY ${PROTO_BINARY_DIR})
 set(PROTO_IMPORT_DIRS proto/)
 
-set(SOURCE_FILES src/iceflow.cpp src/consumer.cpp src/producer.cpp
-                 src/measurements.cpp)
+set(SOURCE_FILES
+    src/iceflow.cpp src/consumer.cpp src/producer.cpp src/measurements.cpp
+    src/node-instance-service.cpp src/scaler.cpp)
 
 add_library(iceflow SHARED ${SOURCE_FILES} proto/iceflow.proto)
 

--- a/examples/wordCount/lines2words/lines2words1.yaml
+++ b/examples/wordCount/lines2words/lines2words1.yaml
@@ -4,9 +4,7 @@ nodePrefix: text2lines1
 consumer:
   topic: /text2lines/dataMain
   inputThreshold: 200 # TODO: This is unused at the moment
-  totalNumberOfConsumers: 2
-  partitionIndex: 0
-  numberOfPartitions: 3
+  partitions: [1, 3]
 
 producer:
   topic: /lines2words/dataMain

--- a/examples/wordCount/lines2words/lines2words2.yaml
+++ b/examples/wordCount/lines2words/lines2words2.yaml
@@ -4,9 +4,7 @@ nodePrefix: text2lines2
 consumer:
   topic: /text2lines/dataMain
   inputThreshold: 200 # TODO: This is unused at the moment
-  totalNumberOfConsumers: 2
-  partitionIndex: 1
-  numberOfPartitions: 3
+  partitions: [2]
 
 producer:
   topic: /lines2words/dataMain

--- a/examples/wordCount/wordcount/wordcount.cpp
+++ b/examples/wordCount/wordcount/wordcount.cpp
@@ -62,16 +62,15 @@ private:
 };
 
 void run(const std::string &syncPrefix, const std::string &nodePrefix,
-         const std::string &subTopic, uint32_t numberOfPartitions,
-         uint32_t consumerPartitionIndex, uint32_t totalNumberOfConsumers) {
+         const std::string &subTopic,
+         std::vector<uint32_t> consumerPartitions) {
   WordCounter compute;
   ndn::Face face;
 
   auto iceflow =
       std::make_shared<iceflow::IceFlow>(syncPrefix, nodePrefix, face);
   auto consumer =
-      iceflow::IceflowConsumer(iceflow, subTopic, numberOfPartitions,
-                               consumerPartitionIndex, totalNumberOfConsumers);
+      iceflow::IceflowConsumer(iceflow, subTopic, consumerPartitions);
 
   std::vector<std::thread> threads;
   threads.emplace_back(&iceflow::IceFlow::run, iceflow);
@@ -106,12 +105,8 @@ int main(int argc, const char *argv[]) {
   std::string syncPrefix = config["syncPrefix"].as<std::string>();
   std::string nodePrefix = config["nodePrefix"].as<std::string>();
   std::string subTopic = consumerConfig["topic"].as<std::string>();
-  uint32_t consumerPartitionIndex =
-      consumerConfig["partitionIndex"].as<uint32_t>();
-  uint32_t totalNumberOfConsumers =
-      consumerConfig["totalNumberOfConsumers"].as<uint32_t>();
-  uint32_t numberOfPartitions =
-      consumerConfig["numberOfPartitions"].as<uint32_t>();
+  auto consumerPartitions =
+      consumerConfig["partitions"].as<std::vector<uint32_t>>();
 
   uint64_t saveThreshold = measurementConfig["saveThreshold"].as<uint64_t>();
 
@@ -120,8 +115,7 @@ int main(int argc, const char *argv[]) {
                                                 saveThreshold, "A");
 
   try {
-    run(syncPrefix, nodePrefix, subTopic, numberOfPartitions,
-        consumerPartitionIndex, totalNumberOfConsumers);
+    run(syncPrefix, nodePrefix, subTopic, consumerPartitions);
   }
 
   catch (const std::exception &e) {

--- a/examples/wordCount/wordcount/wordcount.yaml
+++ b/examples/wordCount/wordcount/wordcount.yaml
@@ -3,9 +3,7 @@ nodePrefix: wordcount
 
 consumer:
   topic: /lines2words/dataMain
-  totalNumberOfConsumers: 1
-  partitionIndex: 0
-  numberOfPartitions: 1
+  partitions: [1]
 
 measurements:
   saveThreshold: 100

--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1717507522,
-        "narHash": "sha256-yE/djn0anGdWQ2yfiE8m82VXvWwB0+CIgEvjW8GfGlc=",
+        "lastModified": 1722262342,
+        "narHash": "sha256-bKNPr3GVhV7DgkEWyNxG0vM1ZJq/SAlrRA8TNs+rrbk=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "8485851fadfce27d394fabbc4ccb679c84f8c0dc",
+        "rev": "11a1ca0ad80bc172d2efda34ae542494442dcf48",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1717555607,
-        "narHash": "sha256-WZ1s48OODmRJ3DHC+I/DtM3tDRuRJlNqMvxvAPTD7ec=",
+        "lastModified": 1722087241,
+        "narHash": "sha256-2ShmEaFi0kJVOEEu5gmlykN5dwjWYWYUJmlRTvZQRpU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0b8e7a1ae5a94da2e1ee3f3030a32020f6254105",
+        "rev": "8c50662509100d53229d4be607f1a3a31157fa12",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     let
       forEachSystem = nixpkgs.lib.genAttrs (import systems);
       # Define build dependencies for IceFlow (will be added both to the devShell and to the package build).
-      iceflowDependencies = ["yaml-cpp" "nlohmann_json" "boost179" "ndn-svs" "ndn-cxx"];
+      iceflowDependencies = ["yaml-cpp" "nlohmann_json" "boost179" "ndn-svs" "ndn-cxx" "grpc" "openssl" "protobuf"];
     in {
 
       overlays.default = final: prev: let

--- a/include/iceflow/consumer.hpp
+++ b/include/iceflow/consumer.hpp
@@ -32,8 +32,7 @@ class IceflowConsumer {
 
 public:
   IceflowConsumer(std::shared_ptr<IceFlow> iceflow, const std::string &subTopic,
-                  uint32_t numberOfPartitions, uint32_t consumerPartitionIndex,
-                  uint32_t totalNumberOfConsumers);
+                  std::vector<uint32_t> partitions);
 
   ~IceflowConsumer();
 
@@ -44,11 +43,9 @@ public:
    */
   bool hasData();
 
-  void setNumberOfPartitions(uint32_t numberOfPartitions);
+  bool repartition(std::vector<uint32_t> partitions);
 
-  void setConsumerPartitionIndex(uint32_t consumerPartitionIndex);
-
-  void setTotalNumberOfConsumers(uint32_t totalNumberOfConsumers);
+  std::vector<u_int32_t> getPartitions();
 
 private:
   void validatePartitionConfiguration(uint32_t numberOfPartitions,
@@ -73,9 +70,7 @@ private:
   const std::weak_ptr<IceFlow> m_iceflow;
   const std::string m_subTopic;
 
-  uint32_t m_numberOfPartitions;
-  uint32_t m_consumerPartitionIndex;
-  uint32_t m_totalNumberOfConsumers;
+  std::vector<uint32_t> m_partitions;
 
   std::unordered_map<uint32_t, uint32_t> m_subscriptionHandles;
 

--- a/include/iceflow/node-instance-service.hpp
+++ b/include/iceflow/node-instance-service.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ICEFLOW_NODE_INSTANCE_SERVICE_H
+#define ICEFLOW_NODE_INSTANCE_SERVICE_H
+
+#include "consumer.hpp"
+#include <iceflow.grpc.pb.h>
+#include <iceflow.pb.h>
+
+#include <grpc/grpc.h>
+#include <grpcpp/server_builder.h>
+
+namespace iceflow {
+
+class NodeInstanceService final : public NodeInstance::Service {
+public:
+  explicit NodeInstanceService(std::weak_ptr<IceflowConsumer> consumer);
+
+public:
+  virtual grpc::Status Repartition(grpc::ServerContext *context,
+                                   const RepartitionRequest *request,
+                                   RepartitionResponse *response);
+
+private:
+  std::weak_ptr<IceflowConsumer> m_consumer;
+};
+} // namespace iceflow
+
+#endif // ICEFLOW_NODE_INSTANCE_SERVICE_H

--- a/include/iceflow/scaler.hpp
+++ b/include/iceflow/scaler.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ICEFLOW_SCALER_HPP
+#define ICEFLOW_SCALER_HPP
+
+#include "iceflow.hpp"
+
+namespace iceflow {
+
+class IceflowScaler {
+public:
+  IceflowScaler(std::shared_ptr<IceflowConsumer> consumer,
+                const std::string &serverAddress);
+
+  ~IceflowScaler();
+
+private:
+  void runGrpcServer(const std::string &address);
+
+private:
+  std::shared_ptr<IceflowConsumer> m_consumer;
+
+  const std::string &m_serverAddress;
+
+  std::unique_ptr<grpc::Server> m_server;
+};
+} // namespace iceflow
+
+#endif // ICEFLOW_SCALER_HPP

--- a/proto/iceflow.proto
+++ b/proto/iceflow.proto
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package iceflow;
+
+// Service definition for repartitioning node instances.
+service NodeInstance {
+  // Performs the repartition of a node instance.
+  rpc Repartition(RepartitionRequest) returns (RepartitionResponse) {}
+}
+
+// The request message for repartitioning a node instance.
+//
+// Expects a lower and an upper partition bound for the new partition range.
+message RepartitionRequest {
+  required int32 lower_partition_bound = 1;
+  required int32 upper_partition_bound = 2;
+}
+
+// The response message that indicates whether repartitioning was successful.
+//
+// Will also report the current/updated lower and upper partition bounds defined
+// for the node instance.
+message RepartitionResponse {
+  required bool success = 1;
+  optional int32 lower_partition_bound = 2;
+  optional int32 upper_partition_bound = 3;
+}

--- a/src/node-instance-service.cpp
+++ b/src/node-instance-service.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "node-instance-service.hpp"
+
+namespace iceflow {
+
+NodeInstanceService::NodeInstanceService(
+    std::weak_ptr<IceflowConsumer> consumer)
+    : m_consumer(consumer){};
+
+grpc::Status NodeInstanceService::Repartition(grpc::ServerContext *context,
+                                              const RepartitionRequest *request,
+                                              RepartitionResponse *response) {
+  if (auto validConsumer = m_consumer.lock()) {
+
+    auto lowerPartitionBound = request->lower_partition_bound();
+    auto upperPartitionBound = request->upper_partition_bound();
+
+    std::cout
+        << "Server: Repartition for NodeInstance with new partition range: "
+        << lowerPartitionBound << "--" << upperPartitionBound << "."
+        << std::endl;
+
+    auto partitions =
+        std::vector<uint32_t>(lowerPartitionBound, upperPartitionBound);
+
+    auto isSuccess = validConsumer->repartition(partitions);
+
+    response->set_success(isSuccess);
+    response->set_lower_partition_bound(lowerPartitionBound);
+    response->set_upper_partition_bound(upperPartitionBound);
+
+    return grpc::Status::OK;
+  }
+
+  return grpc::Status(grpc::StatusCode::INTERNAL,
+                      "NodeInstanceService has already been shut down");
+}
+} // namespace iceflow

--- a/src/scaler.cpp
+++ b/src/scaler.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ndn-cxx/util/logger.hpp"
+
+#include "node-instance-service.hpp"
+#include "scaler.hpp"
+
+namespace iceflow {
+
+NDN_LOG_INIT(iceflow.IceflowScaler);
+
+IceflowScaler::IceflowScaler(std::shared_ptr<IceflowConsumer> consumer,
+                             const std::string &serverAddress)
+    : m_consumer(consumer), m_serverAddress(serverAddress) {
+  runGrpcServer(m_serverAddress);
+};
+
+IceflowScaler::~IceflowScaler() {
+  if (m_server) {
+    m_server->Shutdown();
+  }
+}
+
+void IceflowScaler::runGrpcServer(const std::string &address) {
+  NodeInstanceService service(m_consumer);
+
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort(address, grpc::InsecureServerCredentials());
+  builder.RegisterService(&service);
+  m_server = builder.BuildAndStart();
+  NDN_LOG_INFO("Server listening on " << address);
+}
+} // namespace iceflow


### PR DESCRIPTION
This PR implements an initial mechanism for triggering a repartitioning of an `IceflowConsumer` via gRPC (using, for instance, a Unix socket for exchanging messages with a gRPC client) using a new `IceflowScaler` class and a `NodeInstanceService` for the gRPC server it contains. The gRPC code is automatically generated at compile-time using the `protobuf_generate` function in the top-level `CMakeLists.txt`.

While implementing the scaling functionality, I've noticed that certain aspects of the repartitioning mechanism within the `IceflowConsumer` class could be simplified a bit. Therefore, this PR does not only add new code, but also changes existing parts of the implementation.