### PR TITLE
refactor(producer): remove obsolete definitions in cpp file

### DIFF
--- a/src/producer.cpp
+++ b/src/producer.cpp
@@ -116,18 +116,4 @@ std::chrono::time_point<std::chrono::steady_clock>
 IceflowProducer::getNextPublishTimePoint() {
   return m_lastPublishTimePoint + m_publishInterval;
 }
-
-const std::weak_ptr<IceFlow> m_iceflow;
-const std::string m_pubTopic;
-RingBuffer<std::vector<uint8_t>> m_outputQueue;
-
-uint32_t m_numberOfPartitions;
-std::unordered_set<uint32_t> m_topicPartitions;
-
-std::chrono::nanoseconds m_publishInterval;
-std::chrono::time_point<std::chrono::steady_clock> m_lastPublishTimePoint;
-
-uint64_t m_subscriberId;
-
-std::mt19937 m_randomNumberGenerator;
 } // namespace iceflow


### PR DESCRIPTION
As a spin-off from #79, this PR removes some unused definitions from the `producer.cpp` file that got copied over by accident.