### PR TITLE
fix: use uint32 instead of int32 in protobuf definitions

### DIFF
--- a/proto/iceflow.proto
+++ b/proto/iceflow.proto
@@ -28,8 +28,8 @@ service NodeInstance {
 //
 // Expects a lower and an upper partition bound for the new partition range.
 message RepartitionRequest {
-  required int32 lower_partition_bound = 1;
-  required int32 upper_partition_bound = 2;
+  required uint32 lower_partition_bound = 1;
+  required uint32 upper_partition_bound = 2;
 }
 
 // The response message that indicates whether repartitioning was successful.
@@ -38,6 +38,6 @@ message RepartitionRequest {
 // for the node instance.
 message RepartitionResponse {
   required bool success = 1;
-  optional int32 lower_partition_bound = 2;
-  optional int32 upper_partition_bound = 3;
+  optional uint32 lower_partition_bound = 2;
+  optional uint32 upper_partition_bound = 3;
 }


### PR DESCRIPTION
As another spin-off from #79, this PR changes the signature of the protobuf messages to use unsigned instead of signed integers.