### PR TITLE
feat!: update syntax to protobuf3

### DIFF
--- a/proto/iceflow.proto
+++ b/proto/iceflow.proto
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+syntax = "proto3";
+
 package iceflow;
 
 // Service definition for repartitioning node instances.
@@ -28,8 +30,8 @@ service NodeInstance {
 //
 // Expects a lower and an upper partition bound for the new partition range.
 message RepartitionRequest {
-  required uint32 lower_partition_bound = 1;
-  required uint32 upper_partition_bound = 2;
+  uint32 lower_partition_bound = 1;
+  uint32 upper_partition_bound = 2;
 }
 
 // The response message that indicates whether repartitioning was successful.
@@ -37,7 +39,7 @@ message RepartitionRequest {
 // Will also report the current/updated lower and upper partition bounds defined
 // for the node instance.
 message RepartitionResponse {
-  required bool success = 1;
-  optional uint32 lower_partition_bound = 2;
-  optional uint32 upper_partition_bound = 3;
+  bool success = 1;
+  uint32 lower_partition_bound = 2;
+  uint32 upper_partition_bound = 3;
 }


### PR DESCRIPTION
This PR updates the `iceflow.proto` file to use the protobuf3 syntax. Since according to the [protobuf best practices](https://protobuf.dev/programming-guides/dos-donts/), using required fields is discouraged, this allows us to remove the `required` specifier, making our protobuf definitions more future-proof.