### PR TITLE
Fix minor typos and whitespace issues

### DIFF
--- a/doc/Nix-Developer-Guide.md
+++ b/doc/Nix-Developer-Guide.md
@@ -3,14 +3,14 @@ Nix is a declarative package manager that allows for easily reproducible develop
 description file written in the Nix programming language.
 For more detailed information regarding Nix, see https://nixos.org/.
 
-This document provides documentation regarding the use of Nix for IceFlow development, as well as instructions on 
+This document provides documentation regarding the use of Nix for IceFlow development, as well as instructions on
 how to change or update dependencies and some explanations regarding the configuration file.
 
 ## Using Nix for IceFlow development
-IceFlow provides a Nix Flake, which provides a development environment using the Nix-based tool 
+IceFlow provides a Nix Flake, which provides a development environment using the Nix-based tool
 [devenv.sh](https://devenv.sh).
 
-In order to compile IceFlow in the Nix environment, you may follow the 
+In order to compile IceFlow in the Nix environment, you may follow the
 [Nix section of the installation instructions](../Install.md#using-nix-and-devenvsh).
 
 By default, the development shell will include debug symbols for all dependencies except OpenCV.
@@ -21,7 +21,7 @@ nix develop --impure '.#debugall'
 Note, however, that this will compile OpenCV on your local system, which might take a while and a considerable amount
 of resources.
 
-Some IDEs may allow for direct integration with devenv.sh, see 
+Some IDEs may allow for direct integration with devenv.sh, see
 [the devenv.sh documentation](https://devenv.sh/getting-started/), most notably the section on "Editor Support".
 For VSCode, refer to https://devenv.sh/editor-support/vscode/.
 If you are using JetBrains IDEs (CLion), refer to the following section.
@@ -29,13 +29,13 @@ If you are using JetBrains IDEs (CLion), refer to the following section.
 ### Using the Nix environment in CLion
 A plugin for adding syntax highlighting and linting to .nix files can be found [here](https://github.com/NixOS/nix-idea).
 
-Unfortunately, CLion does not have direct support for Nix integration (i.e. automatically enabling a Nix environment 
-configured for a project and using its compiler, libraries and debugger), even though this feature has been requested 
+Unfortunately, CLion does not have direct support for Nix integration (i.e. automatically enabling a Nix environment
+configured for a project and using its compiler, libraries and debugger), even though this feature has been requested
 both for [the IDE itself](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360008227939-How-to-configure-a-Nix-based-remote-interpreter) and the [the nix-idea plugin](https://github.com/NixOS/nix-idea/issues/1).
 
-So far, the easiest way to use Nix in CLion is by simply starting it from the command line while inside the Nix 
+So far, the easiest way to use Nix in CLion is by simply starting it from the command line while inside the Nix
 development shell.
-This allows you to configure a toolchain in CLion that uses the Nix environment by simply specifying the command names 
+This allows you to configure a toolchain in CLion that uses the Nix environment by simply specifying the command names
 without an absolute path:
 ![Nix toolchain configuration in CLion](nix_clion.png)
 
@@ -69,7 +69,7 @@ The generated images can be found using the `result` symlink in a format importa
 podman load < result
 ```
 
-> [!NOTE]  
+> [!NOTE]
 > If you encounter an error when importing the image, it might help to first `gunzip` the image before importing.
 
 Running the container can then be done using:
@@ -91,11 +91,11 @@ For updating packages that are defined in the `flake.nix` file itself:
 1. Update the `src` attribute of the package in the `flake.nix` file as follows:
     - Update the `rev` to the git revision (commit hash or tag) you want to switch to.
     - Change a single character of the `hash` attribute (otherwise Nix will think that it doesn't have to redownload)
-2. Save and close the file and reload the Nix environment (will happen automatically when using direnv). 
-    This *will* fail, as the downloaded hash doesn't match, but the error message will provide you with the correct 
+2. Save and close the file and reload the Nix environment (will happen automatically when using direnv).
+    This *will* fail, as the downloaded hash doesn't match, but the error message will provide you with the correct
     hash of the downloaded new revision.
 3. Update the `hash` attribute of the package again, this time using the hash given in the error message.
-4. Save and close the file again. This time, the build should succeed (assuming there are no actualy compilation issues).
+4. Save and close the file again. This time, the build should succeed (assuming there are no actually compilation issues).
 
 ### Defining a dependency
 Most basic dependencies are already available in the nixpkgs repository.
@@ -138,10 +138,10 @@ let pkg-overlay = (final: prev: rec {
         owner = "named-data";
         repo = "ndn-cxx";
         rev = "18ccbb3b1f600d913dd42dd5c462afdac77e37e0";
-        hash = "sha256-yHsp6dBq2kMsubJrn77qeQ9Ah+Udy7nE9eWBX2smemA="; 
-        fetchSubmodules = true; 
+        hash = "sha256-yHsp6dBq2kMsubJrn77qeQ9Ah+Udy7nE9eWBX2smemA=";
+        fetchSubmodules = true;
       };
-    
+
     });
 });
 in {}

--- a/examples/wordCount/lines2words/lines2words.cpp
+++ b/examples/wordCount/lines2words/lines2words.cpp
@@ -31,9 +31,9 @@ public:
       auto line = receive();
       measurementHandler->setField(std::to_string(computeCounter), "CMP_START",
                                    0);
-      std::stringstream streamedlines(line);
+      std::stringstream streamedLines(line);
       std::string word;
-      while (streamedlines >> word) {
+      while (streamedLines >> word) {
         std::cout << word << std::endl;
         push(word);
         measurementHandler->setField(std::to_string(computeCounter),

--- a/include/iceflow/ringbuffer.hpp
+++ b/include/iceflow/ringbuffer.hpp
@@ -119,7 +119,7 @@ public:
   }
 
   /**
-   *@brief Tries to pop an item fron the queue and returns a std::shared_ptr<T>
+   *@brief Tries to pop an item from the queue and returns a std::shared_ptr<T>
    *This is a non blocking call and returns immediately with a status of
    *retrieval.
    *
@@ -140,7 +140,7 @@ public:
    *in as an argument This is a blocking call and it waits until an item is
    *available to be popped.
    *
-   *@param value An intance to which the popped item is to be copied to.
+   *@param value An instance to which the popped item is to be copied to.
    */
   void waitAndPop(T &value) {
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -187,9 +187,9 @@ public:
    *in as an argument. This is a blocking call with a timeout functionality.
    *
    *@param value An instance to which the popped item is to be copied to.
-   *@param waitDuration Wait for atmost waitDuration.
+   *@param waitDuration Wait for at most waitDuration.
    *@return returns false if the wait timedout, returns true if an item was
-   *poped and copied.
+   *popped and copied.
    */
   bool waitForAndPop(T &value, std::chrono::milliseconds waitDuration) {
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -208,7 +208,7 @@ public:
    *@brief Waits and pops an item from the queue and returns a
    *std::shared_ptr<T>. This is a blocking call with a timeout functionality.
    *
-   *@param waitDuration Wait for atmost waitDuration
+   *@param waitDuration Wait for at most waitDuration
    *@return returns nullptr if it timed out, else returns a std::shared_ptr<T>
    *pointing to an instance of item popped.
    */


### PR DESCRIPTION
In the context of #79, I've noticed a couple of minor typos and whitespace issues. This PR performs some trivial cleanup.

After the merge of this PR (and #83), I will rebase #79 once again for a cleaner commit history.