### PR TITLE
refactor: split protobuf definitions into separate files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,8 @@ set(SOURCE_FILES
     src/scaler.cpp
     src/executor.cpp)
 
-add_library(iceflow SHARED ${SOURCE_FILES} proto/iceflow.proto)
+add_library(iceflow SHARED ${SOURCE_FILES} proto/iceflow/node-executor.proto
+                           proto/iceflow/node-instance.proto)
 
 target_compile_options(iceflow PRIVATE -D_GNU_SOURCE -DBOOST_LOG_DYN_LINK)
 target_link_libraries(

--- a/include/iceflow/executor.hpp
+++ b/include/iceflow/executor.hpp
@@ -21,7 +21,8 @@
 
 #include "iceflow.hpp"
 
-#include <iceflow.grpc.pb.h>
+#include <iceflow/node-executor.grpc.pb.h>
+#include <iceflow/node-instance.grpc.pb.h>
 
 #include <grpc/grpc.h>
 

--- a/include/iceflow/node-executor-service.hpp
+++ b/include/iceflow/node-executor-service.hpp
@@ -19,8 +19,8 @@
 #ifndef ICEFLOW_NODE_EXECUTOR_SERVICE_H
 #define ICEFLOW_NODE_EXECUTOR_SERVICE_H
 
-#include <iceflow.grpc.pb.h>
-#include <iceflow.pb.h>
+#include <iceflow/node-executor.grpc.pb.h>
+#include <iceflow/node-executor.pb.h>
 
 #include <grpc/grpc.h>
 #include <grpcpp/server_builder.h>

--- a/include/iceflow/node-instance-service.hpp
+++ b/include/iceflow/node-instance-service.hpp
@@ -20,8 +20,9 @@
 #define ICEFLOW_NODE_INSTANCE_SERVICE_H
 
 #include "consumer.hpp"
-#include <iceflow.grpc.pb.h>
-#include <iceflow.pb.h>
+
+#include <iceflow/node-instance.grpc.pb.h>
+#include <iceflow/node-instance.pb.h>
 
 #include <grpc/grpc.h>
 #include <grpcpp/server_builder.h>

--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -24,7 +24,8 @@
 
 #include <time.h>
 
-#include <iceflow.grpc.pb.h>
+#include <iceflow/node-executor.grpc.pb.h>
+#include <iceflow/node-executor.pb.h>
 
 #include "iceflow.hpp"
 

--- a/proto/iceflow/node-executor.proto
+++ b/proto/iceflow/node-executor.proto
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+syntax = "proto3";
+
+package iceflow;
+
+service NodeExecutor {
+  /// Sends a report about a congestion on an edge within the Iceflow system
+  /// to the NodeExecutor.
+  rpc ReportCongestion(CongestionReportRequest)
+      returns (CongestionReportResponse);
+}
+
+message CongestionReportRequest {
+  /// The specifier of the congested edge.
+  string edge_name = 1;
+
+  /// An identifier of the cause for the congestion.
+  CongestionReason congestion_reason = 2;
+  // TODO: Should the amount of congestion be quantified somehow?
+}
+
+message CongestionReportResponse {}
+
+/// Enumeration of reasons why a NodeInstance can become congested.
+enum CongestionReason {
+  /// The congestion is caused by insufficient network capacity, reported via
+  /// congestion marks attached to NDN messages.
+  CONGESTION_REASON_NETWORK = 0;
+
+  /// The congestion is caused by insufficient computing resources, causing the
+  /// producer's queue to fill up.
+  CONGESTION_REASON_PROCESSING = 1;
+}

--- a/proto/iceflow/node-instance.proto
+++ b/proto/iceflow/node-instance.proto
@@ -43,32 +43,3 @@ message RepartitionResponse {
   uint32 lower_partition_bound = 2;
   uint32 upper_partition_bound = 3;
 }
-
-service NodeExecutor {
-  /// Sends a report about a congestion on an edge within the Iceflow system
-  /// to the NodeExecutor.
-  rpc ReportCongestion(CongestionReportRequest)
-      returns (CongestionReportResponse);
-}
-
-message CongestionReportRequest {
-  /// The specifier of the congested edge.
-  string edge_name = 1;
-
-  /// An identifier of the cause for the congestion.
-  CongestionReason congestion_reason = 2;
-  // TODO: Should the amount of congestion be quantified somehow?
-}
-
-message CongestionReportResponse {}
-
-/// Enumeration of reasons why a NodeInstance can become congested.
-enum CongestionReason {
-  /// The congestion is caused by insufficient network capacity, reported via
-  /// congestion marks attached to NDN messages.
-  CONGESTION_REASON_NETWORK = 0;
-
-  /// The congestion is caused by insufficient computing resources, causing the
-  /// producer's queue to fill up.
-  CONGESTION_REASON_PROCESSING = 1;
-}


### PR DESCRIPTION
This PR performs a minor refactoring and splits the Protobuf definitions in separate files per service.