### PR TITLE
Add implementation of production and consumption stats RPCs

### DIFF
--- a/include/iceflow/congestion-reporter.hpp
+++ b/include/iceflow/congestion-reporter.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 The IceFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ICEFLOW_CONGESTION_REPORTER_HPP
+#define ICEFLOW_CONGESTION_REPORTER_HPP
+
+#include <iceflow/node-executor.pb.h>
+
+namespace iceflow {
+
+class CongestionReporter {
+public:
+  virtual ~CongestionReporter() {}
+
+  virtual void reportCongestion(CongestionReason congestionReason,
+                                const std::string &edgeName) = 0;
+};
+
+} // namespace iceflow
+
+#endif // ICEFLOW_CONGESTION_REPORTER_HPP

--- a/include/iceflow/consumer.hpp
+++ b/include/iceflow/consumer.hpp
@@ -19,7 +19,8 @@
 #ifndef ICEFLOW_CONSUMER_HPP
 #define ICEFLOW_CONSUMER_HPP
 
-#include <unordered_set>
+#include <chrono>
+#include <unordered_map>
 
 #include "congestion-reporter.hpp"
 #include "iceflow.hpp"
@@ -48,6 +49,8 @@ public:
 
   std::vector<u_int32_t> getPartitions();
 
+  u_int32_t getConsumptionStats();
+
 private:
   void validatePartitionConfiguration(uint32_t numberOfPartitions,
                                       uint32_t consumerPartitionIndex,
@@ -67,6 +70,11 @@ private:
 
   void unsubscribeFromAllPartitions();
 
+  void saveTimestamp();
+
+  void cleanUpTimestamps(
+      std::chrono::time_point<std::chrono::steady_clock> referenceTimepoint);
+
 private:
   const std::weak_ptr<IceFlow> m_iceflow;
   const std::string m_subTopic;
@@ -76,6 +84,12 @@ private:
   std::unordered_map<uint32_t, uint32_t> m_subscriptionHandles;
 
   RingBuffer<std::vector<uint8_t>> m_inputQueue;
+
+  std::deque<std::chrono::time_point<std::chrono::steady_clock>>
+      m_consumptionTimestamps;
+
+  // TODO: Make configurable
+  std::chrono::seconds m_maxConsumptionAge = std::chrono::seconds(1);
 };
 } // namespace iceflow
 

--- a/include/iceflow/consumer.hpp
+++ b/include/iceflow/consumer.hpp
@@ -21,6 +21,7 @@
 
 #include <unordered_set>
 
+#include "congestion-reporter.hpp"
 #include "iceflow.hpp"
 
 namespace iceflow {

--- a/include/iceflow/node-instance-service.hpp
+++ b/include/iceflow/node-instance-service.hpp
@@ -19,7 +19,10 @@
 #ifndef ICEFLOW_NODE_INSTANCE_SERVICE_H
 #define ICEFLOW_NODE_INSTANCE_SERVICE_H
 
+#include <unordered_map>
+
 #include "consumer.hpp"
+#include "producer.hpp"
 
 #include <iceflow/node-instance.grpc.pb.h>
 #include <iceflow/node-instance.pb.h>
@@ -31,15 +34,27 @@ namespace iceflow {
 
 class NodeInstanceService final : public NodeInstance::Service {
 public:
-  explicit NodeInstanceService(std::weak_ptr<IceflowConsumer> consumer);
+  explicit NodeInstanceService(
+      std::unordered_map<std::string, std::shared_ptr<IceflowConsumer>>
+          &consumerMap,
+      std::unordered_map<std::string, std::shared_ptr<IceflowProducer>>
+          &producerMap);
 
 public:
   virtual grpc::Status Repartition(grpc::ServerContext *context,
                                    const RepartitionRequest *request,
                                    RepartitionResponse *response);
 
+  virtual grpc::Status QueryStats(grpc::ServerContext *context,
+                                  const StatsRequest *request,
+                                  StatsResponse *response);
+
 private:
-  std::weak_ptr<IceflowConsumer> m_consumer;
+  std::unordered_map<std::string, std::shared_ptr<IceflowConsumer>>
+      &m_consumerMap;
+
+  std::unordered_map<std::string, std::shared_ptr<IceflowProducer>>
+      &m_producerMap;
 };
 } // namespace iceflow
 

--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -57,6 +57,8 @@ public:
 
   void setTopicPartitions(uint64_t numberOfPartitions);
 
+  uint32_t getProductionStats();
+
 private:
   IceflowProducer(
       std::shared_ptr<IceFlow> iceflow, const std::string &pubTopic,
@@ -76,6 +78,11 @@ private:
   void reportCongestion(CongestionReason congestionReason,
                         const std::string &edgeName);
 
+  void saveTimestamp(std::chrono::steady_clock::time_point timestamp);
+
+  void cleanUpTimestamps(
+      std::chrono::time_point<std::chrono::steady_clock> referenceTimepoint);
+
 private:
   const std::weak_ptr<IceFlow> m_iceflow;
   const std::string m_pubTopic;
@@ -92,6 +99,12 @@ private:
   std::mt19937 m_randomNumberGenerator;
 
   std::optional<std::shared_ptr<CongestionReporter>> m_congestionReporter;
+
+  std::deque<std::chrono::time_point<std::chrono::steady_clock>>
+      m_productionTimestamps;
+
+  // TODO: Make configurable
+  std::chrono::seconds m_maxProductionTimestampAge = std::chrono::seconds(1);
 };
 } // namespace iceflow
 

--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -27,16 +27,10 @@
 #include <iceflow/node-executor.grpc.pb.h>
 #include <iceflow/node-executor.pb.h>
 
+#include "congestion-reporter.hpp"
 #include "iceflow.hpp"
 
 namespace iceflow {
-
-class CongestionReporter {
-public:
-  virtual ~CongestionReporter() {}
-  virtual void reportCongestion(CongestionReason congestionReason,
-                                const std::string &edgeName) = 0;
-};
 
 /**
  * Allows for publishing data to `IceflowConsumer`s.

--- a/include/iceflow/scaler.hpp
+++ b/include/iceflow/scaler.hpp
@@ -19,6 +19,8 @@
 #ifndef ICEFLOW_SCALER_HPP
 #define ICEFLOW_SCALER_HPP
 
+#include "congestion-reporter.hpp"
+
 #include "iceflow.hpp"
 #include "producer.hpp"
 

--- a/include/iceflow/scaler.hpp
+++ b/include/iceflow/scaler.hpp
@@ -28,8 +28,7 @@ namespace iceflow {
 
 class IceflowScaler : public CongestionReporter {
 public:
-  IceflowScaler(std::shared_ptr<IceflowConsumer> consumer,
-                const std::string &serverAddress,
+  IceflowScaler(const std::string &serverAddress,
                 const std::string &clientAddress);
 
   ~IceflowScaler() override;
@@ -37,14 +36,22 @@ public:
   void reportCongestion(CongestionReason congestionReason,
                         const std::string &edgeName) override;
 
+  void registerConsumer(const std::string &edgeName,
+                        std::shared_ptr<IceflowConsumer> consumer);
+
+  void deregisterConsumer(const std::string &edgeName);
+
+  void registerProducer(const std::string &edgeName,
+                        std::shared_ptr<IceflowProducer> producer);
+
+  void deregisterProducer(const std::string &edgeName);
+
 private:
   void runGrpcServer(const std::string &address);
 
   void runGrpcClient(const std::string &address);
 
 private:
-  std::shared_ptr<IceflowConsumer> m_consumer;
-
   const std::string &m_serverAddress;
 
   const std::string &m_clientAddress;
@@ -52,6 +59,12 @@ private:
   std::unique_ptr<grpc::Server> m_server;
 
   std::unique_ptr<NodeExecutor::Stub> m_nodeExecutorService;
+
+  std::unordered_map<std::string, std::shared_ptr<IceflowConsumer>>
+      m_consumerMap;
+
+  std::unordered_map<std::string, std::shared_ptr<IceflowProducer>>
+      m_producerMap;
 };
 } // namespace iceflow
 

--- a/proto/iceflow/node-instance.proto
+++ b/proto/iceflow/node-instance.proto
@@ -34,8 +34,9 @@ service NodeInstance {
 //
 // Expects a lower and an upper partition bound for the new partition range.
 message RepartitionRequest {
-  uint32 lower_partition_bound = 1;
-  uint32 upper_partition_bound = 2;
+  string edge_name = 1;
+  uint32 lower_partition_bound = 2;
+  uint32 upper_partition_bound = 3;
 }
 
 // The response message that indicates whether repartitioning was successful.
@@ -43,9 +44,10 @@ message RepartitionRequest {
 // Will also report the current/updated lower and upper partition bounds defined
 // for the node instance.
 message RepartitionResponse {
-  bool success = 1;
-  uint32 lower_partition_bound = 2;
-  uint32 upper_partition_bound = 3;
+  string edge_name = 1;
+  bool success = 2;
+  uint32 lower_partition_bound = 3;
+  uint32 upper_partition_bound = 4;
 }
 
 // The request message for querying production and consumption stats from a node

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <ranges>
+
 #include "ndn-cxx/util/logger.hpp"
 
 #include "consumer.hpp"
@@ -35,7 +37,35 @@ IceflowConsumer::IceflowConsumer(std::shared_ptr<IceFlow> iceflow,
 IceflowConsumer::~IceflowConsumer() { unsubscribeFromAllPartitions(); }
 
 std::vector<uint8_t> IceflowConsumer::receiveData() {
-  return m_inputQueue.waitAndPopValue();
+  auto value = m_inputQueue.waitAndPopValue();
+
+  saveTimestamp();
+
+  return value;
+}
+
+void IceflowConsumer::saveTimestamp() {
+  auto timestamp = std::chrono::steady_clock::now();
+
+  m_consumptionTimestamps.push_back(timestamp);
+
+  cleanUpTimestamps(timestamp);
+}
+
+void IceflowConsumer::cleanUpTimestamps(
+    std::chrono::time_point<std::chrono::steady_clock> referenceTimepoint) {
+
+  while (!m_consumptionTimestamps.empty()) {
+    auto firstValue = m_consumptionTimestamps.front();
+
+    auto timePassed = firstValue - referenceTimepoint;
+
+    if (timePassed <= m_maxConsumptionAge) {
+      break;
+    }
+
+    m_consumptionTimestamps.pop_front();
+  }
 }
 
 /**
@@ -81,6 +111,14 @@ bool IceflowConsumer::repartition(std::vector<uint32_t> partitions) {
   }
 
   return true;
+}
+
+uint32_t IceflowConsumer::getConsumptionStats() {
+  auto referenceTimestamp = std::chrono::steady_clock::now();
+
+  cleanUpTimestamps(referenceTimestamp);
+
+  return m_consumptionTimestamps.size();
 }
 
 uint32_t IceflowConsumer::subscribeToTopicPartition(uint64_t topicPartition) {

--- a/src/producer.cpp
+++ b/src/producer.cpp
@@ -85,6 +85,29 @@ void IceflowProducer::pushData(const std::vector<uint8_t> &data) {
   m_outputQueue.push(data);
 }
 
+void IceflowProducer::saveTimestamp(
+    std::chrono::steady_clock::time_point timestamp) {
+  m_productionTimestamps.push_back(timestamp);
+
+  cleanUpTimestamps(timestamp);
+}
+
+void IceflowProducer::cleanUpTimestamps(
+    std::chrono::time_point<std::chrono::steady_clock> referenceTimepoint) {
+
+  while (!m_productionTimestamps.empty()) {
+    auto firstValue = m_productionTimestamps.front();
+
+    auto timePassed = firstValue - referenceTimepoint;
+
+    if (timePassed <= m_maxProductionTimestampAge) {
+      break;
+    }
+
+    m_productionTimestamps.pop_front();
+  }
+}
+
 void IceflowProducer::setPublishInterval(
     std::chrono::milliseconds publishInterval) {
   if (publishInterval.count() < 0) {
@@ -103,6 +126,14 @@ void IceflowProducer::setTopicPartitions(uint64_t numberOfPartitions) {
   for (uint64_t i = 0; i < numberOfPartitions; ++i) {
     m_topicPartitions.emplace_hint(m_topicPartitions.end(), i);
   }
+}
+
+uint32_t IceflowProducer::getProductionStats() {
+  auto referenceTimestamp = std::chrono::steady_clock::now();
+
+  cleanUpTimestamps(referenceTimestamp);
+
+  return m_productionTimestamps.size();
 }
 
 uint32_t IceflowProducer::getNextPartitionNumber() {
@@ -127,6 +158,8 @@ QueueEntry IceflowProducer::popQueueValue() {
   auto data = m_outputQueue.waitAndPopValue();
   uint32_t partitionNumber = getNextPartitionNumber();
   m_lastPublishTimePoint = std::chrono::steady_clock::now();
+
+  saveTimestamp(m_lastPublishTimePoint);
 
   return {
       m_pubTopic,

--- a/src/scaler.cpp
+++ b/src/scaler.cpp
@@ -28,11 +28,9 @@ namespace iceflow {
 
 NDN_LOG_INIT(iceflow.IceflowScaler);
 
-IceflowScaler::IceflowScaler(std::shared_ptr<IceflowConsumer> consumer,
-                             const std::string &serverAddress,
+IceflowScaler::IceflowScaler(const std::string &serverAddress,
                              const std::string &clientAddress)
-    : m_consumer(consumer), m_serverAddress(serverAddress),
-      m_clientAddress(clientAddress) {
+    : m_serverAddress(serverAddress), m_clientAddress(clientAddress) {
   runGrpcServer(m_serverAddress);
   runGrpcClient(m_clientAddress);
 };
@@ -43,8 +41,26 @@ IceflowScaler::~IceflowScaler() {
   }
 }
 
+void IceflowScaler::registerConsumer(
+    const std::string &edgeName, std::shared_ptr<IceflowConsumer> consumer) {
+  m_consumerMap.emplace(edgeName, consumer);
+}
+
+void IceflowScaler::deregisterConsumer(const std::string &edgeName) {
+  m_consumerMap.erase(edgeName);
+}
+
+void IceflowScaler::registerProducer(
+    const std::string &edgeName, std::shared_ptr<IceflowProducer> consumer) {
+  m_producerMap.emplace(edgeName, consumer);
+}
+
+void IceflowScaler::deregisterProducer(const std::string &edgeName) {
+  m_producerMap.erase(edgeName);
+}
+
 void IceflowScaler::runGrpcServer(const std::string &address) {
-  NodeInstanceService service(m_consumer);
+  NodeInstanceService service(m_consumerMap, m_producerMap);
 
   grpc::ServerBuilder builder;
   builder.AddListeningPort(address, grpc::InsecureServerCredentials());

--- a/src/services/node-instance-service.cpp
+++ b/src/services/node-instance-service.cpp
@@ -21,35 +21,61 @@
 namespace iceflow {
 
 NodeInstanceService::NodeInstanceService(
-    std::weak_ptr<IceflowConsumer> consumer)
-    : m_consumer(consumer){};
+    std::unordered_map<std::string, std::shared_ptr<IceflowConsumer>>
+        &consumerMap,
+    std::unordered_map<std::string, std::shared_ptr<IceflowProducer>>
+        &producerMap)
+    : m_consumerMap(consumerMap), m_producerMap(producerMap){};
 
 grpc::Status NodeInstanceService::Repartition(grpc::ServerContext *context,
                                               const RepartitionRequest *request,
                                               RepartitionResponse *response) {
-  if (auto validConsumer = m_consumer.lock()) {
+  auto edgeName = request->edge_name();
 
-    auto lowerPartitionBound = request->lower_partition_bound();
-    auto upperPartitionBound = request->upper_partition_bound();
-
-    std::cout
-        << "Server: Repartition for NodeInstance with new partition range: "
-        << lowerPartitionBound << "--" << upperPartitionBound << "."
-        << std::endl;
-
-    auto partitions =
-        std::vector<uint32_t>(lowerPartitionBound, upperPartitionBound);
-
-    auto isSuccess = validConsumer->repartition(partitions);
-
-    response->set_success(isSuccess);
-    response->set_lower_partition_bound(lowerPartitionBound);
-    response->set_upper_partition_bound(upperPartitionBound);
-
-    return grpc::Status::OK;
+  if (!m_consumerMap.contains(edgeName)) {
+    return grpc::Status(grpc::StatusCode::NOT_FOUND,
+                        "No consumer defined for edge.");
   }
 
-  return grpc::Status(grpc::StatusCode::INTERNAL,
-                      "NodeInstanceService has already been shut down");
+  auto consumer = m_consumerMap[edgeName];
+
+  auto lowerPartitionBound = request->lower_partition_bound();
+  auto upperPartitionBound = request->upper_partition_bound();
+
+  std::cout << "Server: Repartition for NodeInstance with new partition range: "
+            << lowerPartitionBound << "--" << upperPartitionBound << "."
+            << std::endl;
+
+  auto partitions =
+      std::vector<uint32_t>(lowerPartitionBound, upperPartitionBound);
+
+  auto isSuccess = consumer->repartition(partitions);
+
+  response->set_success(isSuccess);
+  response->set_lower_partition_bound(lowerPartitionBound);
+  response->set_upper_partition_bound(upperPartitionBound);
+
+  return grpc::Status::OK;
+}
+
+grpc::Status NodeInstanceService::QueryStats(grpc::ServerContext *context,
+                                             const StatsRequest *request,
+                                             StatsResponse *response) {
+
+  for (auto consumerMapEntry : m_consumerMap) {
+    auto consumptionStats = response->add_consumption_stats();
+    consumptionStats->set_edge_name(consumerMapEntry.first);
+    consumptionStats->set_units_consumed(
+        consumerMapEntry.second->getConsumptionStats());
+  }
+
+  for (auto producerMapEntry : m_producerMap) {
+    auto productionStats = response->add_production_stats();
+    productionStats->set_edge_name(producerMapEntry.first);
+    productionStats->set_units_produced(
+        producerMapEntry.second->getProductionStats());
+  }
+
+  return grpc::Status::OK;
 }
 } // namespace iceflow

--- a/src/services/node-instance-service.cpp
+++ b/src/services/node-instance-service.cpp
@@ -16,9 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "ndn-cxx/util/logger.hpp"
+
 #include "node-instance-service.hpp"
 
 namespace iceflow {
+
+NDN_LOG_INIT(iceflow.services.NodeInstanceService);
 
 NodeInstanceService::NodeInstanceService(
     std::unordered_map<std::string, std::shared_ptr<IceflowConsumer>>
@@ -42,9 +46,9 @@ grpc::Status NodeInstanceService::Repartition(grpc::ServerContext *context,
   auto lowerPartitionBound = request->lower_partition_bound();
   auto upperPartitionBound = request->upper_partition_bound();
 
-  std::cout << "Server: Repartition for NodeInstance with new partition range: "
-            << lowerPartitionBound << "--" << upperPartitionBound << "."
-            << std::endl;
+  NDN_LOG_INFO("Server: Repartition for edge "
+               << edgeName << " of NodeInstance with new partition range : "
+               << lowerPartitionBound << "--" << upperPartitionBound << ".");
 
   auto partitions =
       std::vector<uint32_t>(lowerPartitionBound, upperPartitionBound);


### PR DESCRIPTION
This PR now finally adds the changes from #88 to the codebase, separated into mostly atomic commits. Besides the one “TODO” line, the changes should be identical, though.