### PR TITLE
fix: also install generated proto and grpc headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,3 +102,8 @@ target_include_directories(
 
 install(TARGETS iceflow DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY include/iceflow DESTINATION include)
+install(
+  DIRECTORY build/generated/iceflow
+  DESTINATION include
+  FILES_MATCHING
+  PATTERN "*.h")


### PR DESCRIPTION
I've noticed that so far, the header files generated by `protobuf_generate` were not installed alongside the non-generated header files when invoking `make install`. This could cause other projects depending on IceFlow to not compile.

This PR slightly adjusts the top-level `CMakeLists.txt` file in order to fix this problem.