### PR TITLE
feat!(executor): replace ExternalExecutor interface with callback

### DIFF
--- a/include/iceflow/executor.hpp
+++ b/include/iceflow/executor.hpp
@@ -33,18 +33,12 @@ struct EdgeStats {
   std::optional<uint64_t> consumed;
 };
 
-class ExternalExecutor {
-public:
-  virtual ~ExternalExecutor() {}
-  virtual void receiveCongestionReport(CongestionReason congestionReason,
-                                       const std::string &edgeName) = 0;
-};
-
 class IceflowExecutor : public std::enable_shared_from_this<IceflowExecutor> {
 public:
   IceflowExecutor(const std::string &serverAddress,
                   const std::string &clientAddress,
-                  std::shared_ptr<ExternalExecutor> externalExecutor);
+                  std::function<void(CongestionReason, const std::string &)>
+                      congestionReportCallback);
 
   ~IceflowExecutor();
 
@@ -69,7 +63,8 @@ private:
 
   std::unique_ptr<NodeInstance::Stub> m_nodeInstanceService;
 
-  std::shared_ptr<ExternalExecutor> m_externalExecutor;
+  std::function<void(CongestionReason, const std::string &)>
+      m_congestionReportCallback;
 };
 } // namespace iceflow
 

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -30,9 +30,10 @@ NDN_LOG_INIT(iceflow.IceflowExecutor);
 
 IceflowExecutor::IceflowExecutor(
     const std::string &serverAddress, const std::string &clientAddress,
-    std::shared_ptr<ExternalExecutor> externalExecutor)
+    std::function<void(CongestionReason, const std::string &)>
+        congestionReportCallback)
     : m_serverAddress(serverAddress), m_clientAddress(clientAddress),
-      m_externalExecutor(externalExecutor) {
+      m_congestionReportCallback(congestionReportCallback) {
   runGrpcServer(m_serverAddress);
   runGrpcClient(m_clientAddress);
 };
@@ -87,7 +88,7 @@ void IceflowExecutor::repartition(uint32_t lowerPartitionBound,
 
 void IceflowExecutor::receiveCongestionReport(CongestionReason congestionReason,
                                               const std::string &edge_name) {
-  m_externalExecutor->receiveCongestionReport(congestionReason, edge_name);
+  m_congestionReportCallback(congestionReason, edge_name);
 }
 
 std::unordered_map<std::string, EdgeStats> IceflowExecutor::queryEdgeStats() {


### PR DESCRIPTION
Trying to use the `ExternalExecutor` interface in practice, I've noticed that it is now really that well usable in practice, as it required to be passed into the `IceflowExecutor` as a shared pointer. To simply things here, this PR replaces the function and the corresponding constructor parameter with a callback function that can be used to handle received congestion reports, which _should_ make things a bit easier to handle, at least for now.

In order to achieve the most elegant and robust solution, we should revisit the relationship of the different classes and the potential interfaces that we need to define later, once we have everything running.