### PR TITLE
chore(.gitignore): ignore versioned shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # Compiled Dynamic libraries
 *.so
+*.so.*
 *.dylib
 *.dll
 


### PR DESCRIPTION
Noticed that the versioned `.so` files that are being generated under Linux (probably since the merge of #94) are currently not properly ignored. This simple PR changes that.