### PR TITLE
fix: fix gRPC plugin cross-compilation issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,12 @@ target_include_directories(proto-objects
 protobuf_generate(TARGET proto-objects IMPORT_DIRS ${PROTO_IMPORT_DIRS}
                   PROTOC_OUT_DIR "${PROTO_BINARY_DIR}")
 
+if(CMAKE_CROSSCOMPILING)
+    set(_gRPC_CPP_PLUGIN "protoc-gen-grpc=${gRPC_CPP_PLUGIN_EXECUTABLE}")
+else()
+    set(_gRPC_CPP_PLUGIN "protoc-gen-grpc=\$<TARGET_FILE:gRPC::grpc_cpp_plugin>")
+endif()
+
 protobuf_generate(
   TARGET
   proto-objects
@@ -75,7 +81,7 @@ protobuf_generate(
   .grpc.pb.h
   .grpc.pb.cc
   PLUGIN
-  "protoc-gen-grpc=\$<TARGET_FILE:gRPC::grpc_cpp_plugin>"
+  ${_gRPC_CPP_PLUGIN}
   IMPORT_DIRS
   ${PROTO_IMPORT_DIRS}
   PROTOC_OUT_DIR


### PR DESCRIPTION
After _a lot_ of fiddling around, I've managed to find a solution to let the cross-compilation succeed again :) Therefore, this PR should resolve #85.

In order to test locally, run (for example) `nix build '.#docker-text2lines-cross.aarch64-linux' --print-out-paths`.