### PR TITLE
Fix DAG parser header not being installed by CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ install(
 install(
   FILES include/iceflow/congestion-reporter.hpp
         include/iceflow/consumer.hpp
+        include/iceflow/dag-parser.hpp
         include/iceflow/executor.hpp
         include/iceflow/iceflow.hpp
         include/iceflow/measurements.hpp


### PR DESCRIPTION
Just a small fix to `CMakeLists.txt` that allows the DAG parser to actually be included.