### PR TITLE
feat(dag-parser): introduce tag field in container object

### DIFF
--- a/dag-syntax.cddl
+++ b/dag-syntax.cddl
@@ -26,6 +26,7 @@ node = {
     executor: "container" / "static",
     container: {
         image: tstr,
+        ? tag: tstr, ; Default tag: latest
         resources: {
             cpu: uint,
             memory: uint,

--- a/include/iceflow/dag-parser.hpp
+++ b/include/iceflow/dag-parser.hpp
@@ -39,6 +39,7 @@ struct Resources {
 
 struct Container {
   std::string image;
+  std::string tag;
   Resources resources;
 };
 

--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -50,14 +50,14 @@ DAGParser DAGParser::parseFromFile(const std::string &filename) {
     nodeInstance.executor = nodeJson.at("executor").get<std::string>();
 
     // Container
-    nodeInstance.container.image =
-        nodeJson.at("container").at("image").get<std::string>();
-    nodeInstance.container.tag =
-        nodeJson.at("container").value("tag", "latest");
+    auto containerJson = nodeJson.at("container");
+
+    nodeInstance.container.image = containerJson.at("image").get<std::string>();
+    nodeInstance.container.tag = containerJson.value("tag", "latest");
     nodeInstance.container.resources.cpu =
-        nodeJson.at("container").at("resources").at("cpu").get<uint32_t>();
+        containerJson.at("resources").at("cpu").get<uint32_t>();
     nodeInstance.container.resources.memory =
-        nodeJson.at("container").at("resources").at("memory").get<uint32_t>();
+        containerJson.at("resources").at("memory").get<uint32_t>();
 
     // Scaling parameters
     nodeInstance.scalingParameters.taskComplexity =

--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -52,6 +52,8 @@ DAGParser DAGParser::parseFromFile(const std::string &filename) {
     // Container
     nodeInstance.container.image =
         nodeJson.at("container").at("image").get<std::string>();
+    nodeInstance.container.tag =
+        nodeJson.at("container").value("tag", "latest");
     nodeInstance.container.resources.cpu =
         nodeJson.at("container").at("resources").at("cpu").get<uint32_t>();
     nodeInstance.container.resources.memory =


### PR DESCRIPTION
This PR adds support for a `tag` field in the application graph's `container` object.

The details might still require some additional discussion, let me know if anything should be changed :)