### PR TITLE
feat(dag-parser): add support for application configurations

### DIFF
--- a/dag-syntax.cddl
+++ b/dag-syntax.cddl
@@ -38,6 +38,7 @@ node = {
         ? payloadSize: uint,
     },
     ? downstream: [ + edge ],
+    ? applicationConfiguration: { * text => any }
 }
 
 edge = {

--- a/include/iceflow/dag-parser.hpp
+++ b/include/iceflow/dag-parser.hpp
@@ -68,6 +68,7 @@ struct Node {
   ScalingParameters scalingParameters;
   CommunicationTask communicationTask;
   std::vector<Edge> downstream;
+  nlohmann::json::object_t applicationConfiguration;
 };
 
 /**

--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -82,6 +82,9 @@ DAGParser DAGParser::parseFromFile(const std::string &filename) {
       nodeInstance.downstream = edges;
     }
 
+    nodeInstance.applicationConfiguration =
+        nodeJson.value("applicationConfiguration", nlohmann::json::object());
+
     nodeList.push_back(nodeInstance);
   }
 


### PR DESCRIPTION
This PR will eventually add support for a flexible application configuration via the application DAG to the codebase. For now, it mostly contains adjustments to the dag parser and the CDDL definitions, which we can discuss before adjusting the rest of the implementation accordingly.