### PR TITLE
feat(dag-parser): improve findUpstreamEdges API

### DIFF
--- a/examples/wordCount/lines2words/lines2words.cpp
+++ b/examples/wordCount/lines2words/lines2words.cpp
@@ -116,7 +116,6 @@ int main(int argc, const char *argv[]) {
   std::string syncPrefix = "/" + dagParser.getApplicationName();
   auto nodePrefix = generateNodePrefix();
   auto node = dagParser.findNodeByName(nodeName);
-  // TODO: Should this method find edges by node name or task ID?
   auto upstreamEdges = dagParser.findUpstreamEdges(node.task);
 
   // TODO: Do this dynamically for all edges

--- a/examples/wordCount/lines2words/lines2words.cpp
+++ b/examples/wordCount/lines2words/lines2words.cpp
@@ -116,7 +116,7 @@ int main(int argc, const char *argv[]) {
   std::string syncPrefix = "/" + dagParser.getApplicationName();
   auto nodePrefix = generateNodePrefix();
   auto node = dagParser.findNodeByName(nodeName);
-  auto upstreamEdges = dagParser.findUpstreamEdges(node.task);
+  auto upstreamEdges = dagParser.findUpstreamEdges(node);
 
   // TODO: Do this dynamically for all edges
   auto downstreamEdge = node.downstream.at(0);

--- a/examples/wordCount/wordcount/wordcount.cpp
+++ b/examples/wordCount/wordcount/wordcount.cpp
@@ -113,7 +113,6 @@ int main(int argc, const char *argv[]) {
   auto nodePrefix = generateNodePrefix();
   auto node = dagParser.findNodeByName(nodeName);
 
-  // TODO: Should this method find edges by node name or task ID?
   auto upstreamEdges = dagParser.findUpstreamEdges(node.task);
   auto upstreamEdge = upstreamEdges.at(0).second;
   auto upstreamEdgeName = upstreamEdge.id;

--- a/examples/wordCount/wordcount/wordcount.cpp
+++ b/examples/wordCount/wordcount/wordcount.cpp
@@ -113,7 +113,7 @@ int main(int argc, const char *argv[]) {
   auto nodePrefix = generateNodePrefix();
   auto node = dagParser.findNodeByName(nodeName);
 
-  auto upstreamEdges = dagParser.findUpstreamEdges(node.task);
+  auto upstreamEdges = dagParser.findUpstreamEdges(node);
   auto upstreamEdge = upstreamEdges.at(0).second;
   auto upstreamEdgeName = upstreamEdge.id;
 

--- a/include/iceflow/dag-parser.hpp
+++ b/include/iceflow/dag-parser.hpp
@@ -92,6 +92,9 @@ public:
   std::vector<std::pair<const Node &, const Edge &>>
   findUpstreamEdges(const std::string &taskId);
 
+  std::vector<std::pair<const Node &, const Edge &>>
+  findUpstreamEdges(const Node &node);
+
 private:
   std::string m_applicationName;
   std::vector<Node> nodes;

--- a/include/iceflow/dag-parser.hpp
+++ b/include/iceflow/dag-parser.hpp
@@ -90,7 +90,7 @@ public:
   const Edge &findEdgeByName(const std::string &edgeId);
 
   std::vector<std::pair<const Node &, const Edge &>>
-  findUpstreamEdges(const std::string &node_name);
+  findUpstreamEdges(const std::string &taskId);
 
 private:
   std::string m_applicationName;

--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -127,6 +127,11 @@ const Edge &DAGParser::findEdgeByName(const std::string &edgeId) {
 }
 
 std::vector<std::pair<const Node &, const Edge &>>
+DAGParser::findUpstreamEdges(const Node &node) {
+  return findUpstreamEdges(node.task);
+}
+
+std::vector<std::pair<const Node &, const Edge &>>
 DAGParser::findUpstreamEdges(const std::string &taskId) {
   std::vector<std::pair<const Node &, const Edge &>> upstreamEdges;
 

--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -127,14 +127,14 @@ const Edge &DAGParser::findEdgeByName(const std::string &edgeId) {
 }
 
 std::vector<std::pair<const Node &, const Edge &>>
-DAGParser::findUpstreamEdges(const std::string &nodeName) {
+DAGParser::findUpstreamEdges(const std::string &taskId) {
   std::vector<std::pair<const Node &, const Edge &>> upstreamEdges;
 
   for (const auto &node : nodes) {
 
     auto it = std::find_if(
         node.downstream.begin(), node.downstream.end(),
-        [&nodeName](const Edge &edge) { return edge.target == nodeName; });
+        [&taskId](const Edge &edge) { return edge.target == taskId; });
 
     if (it != node.downstream.end()) {
       upstreamEdges.emplace_back(node, *it);


### PR DESCRIPTION
When it comes to the DAG parser, I've noticed that the current API for finding upstream edges has a few issues, as the parameter is called `nodeName`, while it actually expects the `task` member of the respective node as input.

This PR proposes a slight API change for making the use of the method a bit more convenient by accepting a reference to the actual node in question instead of a `nodeName`, so that users don't have to worry about what kind of input the method actually expects.