### PR TITLE
fix(ringbuffer.hpp): access m_mutex of other RingBuffer correctly

### DIFF
--- a/include/iceflow/ringbuffer.hpp
+++ b/include/iceflow/ringbuffer.hpp
@@ -55,7 +55,7 @@ public:
    *@param other The instance to be copied from
    */
   RingBuffer(RingBuffer const &other) {
-    std::lock_guard<std::mutex> lock(other->m__mutex);
+    std::lock_guard<std::mutex> lock(other.m_mutex);
     m_queue = other.m_queue;
   }
 


### PR DESCRIPTION
I think I noticed a small bug in the `RingBuffer` class that caused the compilation to fail under certain circumstances. This PR should fix the issue.