### PR TITLE
feat(dag-parser): add applicationConfiguration field to edges

### DIFF
--- a/include/iceflow/dag-parser.hpp
+++ b/include/iceflow/dag-parser.hpp
@@ -55,6 +55,7 @@ struct Edge {
   std::string id;
   std::string target;
   uint32_t maxPartitions;
+  nlohmann::json::object_t applicationConfiguration;
 };
 
 /**

--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -79,6 +79,8 @@ DAGParser DAGParser::parseFromFile(const std::string &filename) {
         edgeInstance.target = edgeJson.at("target").get<std::string>();
         edgeInstance.maxPartitions =
             edgeJson.at("maxPartitions").get<uint32_t>();
+        edgeInstance.applicationConfiguration = edgeJson.value(
+            "applicationConfiguration", nlohmann::json::object());
         edges.push_back(edgeInstance);
       }
       nodeInstance.downstream = edges;


### PR DESCRIPTION
This PR makes the usage of the DAG a bit more flexible by adding an `applicationConfiguration` field to the edges, allowing users to provide custom, application-specific data within their graph definitions.

Depends on #113, which needs to be merged first.