### PR TITLE
fix(iceflow.hpp): improve error handling within getApplicationParameter

### DIFF
--- a/include/iceflow/iceflow.hpp
+++ b/include/iceflow/iceflow.hpp
@@ -126,8 +126,12 @@ public:
       return std::nullopt;
     }
 
-    // TODO: Deal with the case that the key does not have the right type
-    return std::optional(applicationConfiguration.at(key).get<T>());
+    try {
+      auto value = applicationConfiguration.at(key).get<T>();
+      return std::optional(value);
+    } catch (...) {
+      return std::nullopt;
+    }
   }
 
 private:


### PR DESCRIPTION
This PR provides a small potential fix for a TODO I've just noticed in the `iceflow.hpp` class.

Since the method in question is within a header file, we sadly cannot really use the logging macros to report the error, but hopefully the change is still fine.