### PR TITLE
feat!: remove payload size from DAG definition

### DIFF
--- a/dag-syntax.cddl
+++ b/dag-syntax.cddl
@@ -35,9 +35,6 @@ node = {
     scalingParameters: {
         taskComplexity: uint,
     }
-    communicationTask: {
-        ? payloadSize: uint,
-    },
     ? downstream: [ + edge ],
     ? applicationConfiguration: { * text => any }
 }

--- a/examples/wordCount/application-DAG.json
+++ b/examples/wordCount/application-DAG.json
@@ -16,9 +16,6 @@
       "scalingParameters": {
         "taskComplexity": 2
       },
-      "communicationTask": {
-        "payloadSize": 9001
-      },
       "downstream": [
         {
           "id": "t2l",
@@ -42,9 +39,6 @@
           "cpu": 1,
           "memory": 1000000000
         }
-      },
-      "communicationTask": {
-        "payloadSize": 9001
       },
       "scalingParameters": {
         "taskComplexity": 2
@@ -74,9 +68,6 @@
       },
       "scalingParameters": {
         "taskComplexity": 2
-      },
-      "communicationTask": {
-        "payloadSize": 9001
       },
       "applicationConfiguration": {
         "measurementsSaveThreshold": 100

--- a/include/iceflow/dag-parser.hpp
+++ b/include/iceflow/dag-parser.hpp
@@ -47,10 +47,6 @@ struct ScalingParameters {
   uint32_t taskComplexity;
 };
 
-struct CommunicationTask {
-  std::optional<uint32_t> payloadSize;
-};
-
 struct Edge {
   std::string id;
   std::string target;
@@ -68,7 +64,6 @@ struct Node {
   std::string executor;
   Container container;
   ScalingParameters scalingParameters;
-  CommunicationTask communicationTask;
   std::vector<Edge> downstream;
   nlohmann::json::object_t applicationConfiguration;
 };

--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -63,13 +63,6 @@ DAGParser DAGParser::parseFromFile(const std::string &filename) {
     nodeInstance.scalingParameters.taskComplexity =
         nodeJson.at("scalingParameters").at("taskComplexity").get<uint32_t>();
 
-    // Communication task with optional payload size
-    if (nodeJson.contains("communicationTask") &&
-        nodeJson["communicationTask"].contains("payloadSize")) {
-      nodeInstance.communicationTask.payloadSize =
-          nodeJson["communicationTask"]["payloadSize"].get<uint32_t>();
-    }
-
     // downstream edges
     if (nodeJson.contains("downstream")) {
       std::vector<Edge> edges;


### PR DESCRIPTION
Thinking about the `payloadSize` parameter that is currently part of our DAG definition, I've noticed that it is currently not only not being used by the IceFlow implementation but also not really usable with `ndn-svs` at the moment, as the library only works with the max payload size of 8000 bytes for segmentation (see [here](https://github.com/named-data/ndn-svs/blob/1bf5c25dcc3085affae58e87e3e85d0eedee6561/ndn-svs/svspubsub.cpp#L52) and [here](https://github.com/named-data/ndn-svs/blob/1bf5c25dcc3085affae58e87e3e85d0eedee6561/ndn-svs/svspubsub.hpp#L219)), offering no API for setting the payload size manually.

This PR therefore proposes just removing the parameter from the DAG definition to make things clearer for library users. Alternatively, we can also discuss how to better utilize it in applications, but maybe that is not really necessary, at least at the moment.