### PR TITLE
refactor(ci): replace magic-nix-cache with cache-nix-action

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -31,8 +31,10 @@ jobs:
         with:
           packages: skopeo
           version: 1.0
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: nixbuild/nix-quick-install-action@v29
+      - uses: hsel-netsys/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
 
       - name: Build text2lines image
         run: |
@@ -72,8 +74,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: nixbuild/nix-quick-install-action@v29
+      - uses: hsel-netsys/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
 
       - name: Upload manifest
         if: ${{ github.ref != 'main' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-
+      - uses: nixbuild/nix-quick-install-action@v29
+      - uses: hsel-netsys/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+      
       - name: Generate CMake Build Files
         run: nix develop --impure .#ci -c cmake -DBUILD_TESTS=ON .
 
@@ -36,8 +38,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: nixbuild/nix-quick-install-action@v29
+      - uses: hsel-netsys/cache-nix-action@main
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
 
       - name: Generate CMake Build Files
         run: nix develop --impure .#ci -c cmake -DBUILD_TESTS=ON .


### PR DESCRIPTION
This PR replaces the `DeterminateSystems/magic-nix-cache` action with [`nix-community/cache-nix-action`](https://github.com/nix-community/cache-nix-action) (or our fork of it, to be more specific).

This change is required due to [changes in the GitHub caching API](https://github.com/actions/cache/discussions/1510), which are [incompatible with `magic-nix-cache`](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/).

This PR also changes the nix installer action from `DeterminateSystems/nix-installer-action` to `nixbuild/nix-quick-install-action` due to incompatibilities between the former one and `cache-nix-action` (nix-community/cache-nix-action#48)

While the upstream version of cache-nix-action is also affected by these API changes, our own fork updates the underlying GitHub Actions Toolkit to a newer version that supports the new API and should therefore keep working.