### PR TITLE
fix: allow overriding stdenv and pkgs for the iceflow nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
         iceflowPackage = ({crossTarget ? "${system}"}:  let
           pkgs = (import nixpkgs { localSystem = system; crossSystem = crossTarget; }).extend self.overlays.default;
         in 
-          pkgs.callPackage ({enableExamples ? false, enableGRPC ? true}: pkgs.stdenv.mkDerivation {
+          pkgs.callPackage ({enableExamples ? false, enableGRPC ? true, stdenv, pkgs}: stdenv.mkDerivation {
             name = "iceflow";
             src = ./.;
 


### PR DESCRIPTION
This is required for situations where the standard environment needs to be adjusted, e.g., if you want to enable debug symbols using the enableDebugging function.