### PR TITLE
fix(CMakeLists.txt): install `stats.hpp` file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ install(
         include/iceflow/producer.hpp
         include/iceflow/ringbuffer.hpp
         include/iceflow/scaler.hpp
+        include/iceflow/stats.hpp
   DESTINATION include/iceflow)
 
 if(USE_GRPC)


### PR DESCRIPTION
This PR fixes an issue that prevented IceFlow from being usable as a dependency after the addition of the `stats.hpp` file in #124.