### PR TITLE
Allow setting container environment variables (maybe) fix docker images missing libgcc

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -49,7 +49,7 @@ jobs:
           echo WORDCOUNT_IMAGE=$(nix build '.#docker-wordcount-cross.${{ matrix.architecture }}' --print-out-paths) >> "$GITHUB_ENV"
 
       - name: Push image
-        if: ${{ github.ref != 'main' }}
+        if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           export BRANCH_NAME=$(bash -c "echo $GITHUB_REF_NAME | sed -r 's,/,_,g'")
           skopeo copy --all --dest-creds="$REGISTRY_USER:$REGISTRY_PASS" docker-archive:$TEXT2LINES_IMAGE docker://$REGISTRY/iceflow-examples/text2lines/$INPUT_ARCH:$BRANCH_NAME
@@ -59,7 +59,7 @@ jobs:
           INPUT_ARCH: ${{ ( matrix.architecture == 'x86_64-linux' && 'amd64' ) || ( matrix.architecture == 'aarch64-linux' && 'arm64' ) }}
 
       - name: Push image (and update latest tag)
-        if: ${{ github.ref == 'main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           export BRANCH_NAME=$(bash -c "echo $GITHUB_REF_NAME | sed -r 's,/,_,g'")
           skopeo copy --all --additional-tags=latest --dest-creds="$REGISTRY_USER:$REGISTRY_PASS" docker-archive:$TEXT2LINES_IMAGE docker://$REGISTRY/iceflow-examples/text2lines/$INPUT_ARCH:$BRANCH_NAME
@@ -80,7 +80,7 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
 
       - name: Upload manifest
-        if: ${{ github.ref != 'main' }}
+        if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           export BRANCH_NAME=$(bash -c "echo $GITHUB_REF_NAME | sed -r 's,/,_,g'")
           nix develop --impure .#ci -c manifest-tool --username $REGISTRY_USER --password $REGISTRY_PASS push from-args --platforms linux/amd64,linux/arm64 --template $REGISTRY/iceflow-examples/text2lines/ARCH:$BRANCH_NAME --target $REGISTRY/iceflow-examples/text2lines:$BRANCH_NAME
@@ -88,7 +88,7 @@ jobs:
           nix develop --impure .#ci -c manifest-tool --username $REGISTRY_USER --password $REGISTRY_PASS push from-args --platforms linux/amd64,linux/arm64 --template $REGISTRY/iceflow-examples/wordcount/ARCH:$BRANCH_NAME --target $REGISTRY/iceflow-examples/wordcount:$BRANCH_NAME
 
       - name: Upload manifest (and update latest tag)
-        if: ${{ github.ref == 'main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           export BRANCH_NAME=$(bash -c "echo $GITHUB_REF_NAME | sed -r 's,/,_,g'")
           nix develop --impure .#ci -c manifest-tool --username $REGISTRY_USER --password $REGISTRY_PASS push from-args --platforms linux/amd64,linux/arm64 --template $REGISTRY/iceflow-examples/text2lines/ARCH:$BRANCH_NAME --tags latest --target $REGISTRY/iceflow-examples/text2lines:$BRANCH_NAME

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
           name = "iceflow-${example_name}";
           tag = "latest";
 
-          contents = [ (self.packages."${system}".iceflow-cross."${crossTarget}".override {enableExamples = true;}) pkgs.busybox ];
+          contents = [ (self.packages."${system}".iceflow-cross."${crossTarget}".override {enableExamples = true;}) pkgs.busybox pkgs.libgcc];
           architecture = crossTargetContainer;
           config = {
             Cmd = ["sh" "-c" (lib.concatStringsSep " " (["/bin/${example_name}" ] ++ args))];
@@ -131,6 +131,7 @@
             pkgs = nixpkgs.legacyPackages.${system}.extend self.overlays.default;
             lib = nixpkgs.lib;
             # Keep debug symbols disabled for very large packages to avoid long compilation times.
+            # Also, keep it disabled for libraries that do not support overriding (like libgcc).
             keepDebuggingDisabledFor = [];
             additionalShellPackages = with pkgs; [nfd cppcheck manifest-tool];
           in rec {

--- a/include/iceflow/dag-parser.hpp
+++ b/include/iceflow/dag-parser.hpp
@@ -40,6 +40,7 @@ struct Resources {
 struct Container {
   std::string image;
   std::string tag;
+  std::map<std::string, std::string> envs;
   Resources resources;
 };
 

--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -54,6 +54,12 @@ DAGParser DAGParser::parseFromFile(const std::string &filename) {
 
     nodeInstance.container.image = containerJson.at("image").get<std::string>();
     nodeInstance.container.tag = containerJson.value("tag", "latest");
+    if (containerJson.contains("envs")) {
+      nodeInstance.container.envs =
+          containerJson.at("envs").get<std::map<std::string, std::string>>();
+    } else {
+      nodeInstance.container.envs = std::map<std::string, std::string>();
+    }
     nodeInstance.container.resources.cpu =
         containerJson.at("resources").at("cpu").get<uint32_t>();
     nodeInstance.container.resources.memory =


### PR DESCRIPTION
Adds an `envs` field to container DAG fields that allows setting container environment variables.

Also tries to fix issues with the docker container missing libgcc?