### PR TITLE
Fix DAG parser not properly setting the env field + docker images

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
           architecture = crossTargetContainer;
           config = {
             Cmd = ["sh" "-c" (lib.concatStringsSep " " (["/bin/${example_name}" ] ++ args))];
-            Env = [ "ICEFLOW_CONFIG_FILE=/data/${example_name}.yaml" "ICEFLOW_METRICS_FILE=/data/${example_name}.metrics" ];
+            Env = [ "ICEFLOW_CONFIG_FILE=/dag.json" ];
             Volume = "/data";
           };
         };
@@ -106,19 +106,19 @@
 
         docker-text2lines-cross = forEachSystem (crossTarget: genIceflowExampleCtrImage {
           example_name = "text2lines";
-          args = ["$ICEFLOW_CONFIG_FILE" "$ICEFLOW_INPUT_FILE" "$ICEFLOW_METRICS_FILE"];
+          args = ["$ICEFLOW_CONFIG_FILE"];
           crossTarget = crossTarget;
         });
 
         docker-lines2words-cross = forEachSystem (crossTarget: genIceflowExampleCtrImage {
           example_name = "lines2words";
-          args = ["$ICEFLOW_CONFIG_FILE" "$ICEFLOW_METRICS_FILE"];
+          args = ["$ICEFLOW_CONFIG_FILE"];
           crossTarget = crossTarget;
         });
 
         docker-wordcount-cross = forEachSystem (crossTarget: genIceflowExampleCtrImage {
           example_name = "wordcount";
-          args = ["$ICEFLOW_CONFIG_FILE" "$ICEFLOW_METRICS_FILE"];
+          args = ["$ICEFLOW_CONFIG_FILE"];
           crossTarget = crossTarget;
         });
 

--- a/include/iceflow/dag-parser.hpp
+++ b/include/iceflow/dag-parser.hpp
@@ -74,7 +74,7 @@ struct Node {
  */
 class DAGParser {
 public:
-  DAGParser(const std::string &appName, const std::vector<Node> &nodes);
+  DAGParser(const std::string &appName, std::vector<Node> &&nodes);
 
   static DAGParser parseFromFile(const std::string &filename);
 


### PR DESCRIPTION
Had some issues with the previous way that the `envs` field was being parsed.
Also the node list is now passed by value (and moved) to the DAG parser constructor.

Lastly, the docker images now have their CMD arguments set correctly (previously, it still added the metrics file argument, which is no longer passed via the command line).