### PR TITLE
Various smaller fixes in executor and scaler

### DIFF
--- a/include/iceflow/executor.hpp
+++ b/include/iceflow/executor.hpp
@@ -46,15 +46,14 @@ public:
 
   std::unordered_map<std::string, EdgeStats> queryEdgeStats();
 
+  void runGrpcServer();
+
+  void runGrpcClient();
+
 private:
-  void runGrpcServer(const std::string &address);
+  std::string m_serverAddress;
 
-  void runGrpcClient(const std::string &address);
-
-private:
-  const std::string &m_serverAddress;
-
-  const std::string &m_clientAddress;
+  std::string m_clientAddress;
 
   std::unique_ptr<grpc::Server> m_server;
 

--- a/include/iceflow/scaler.hpp
+++ b/include/iceflow/scaler.hpp
@@ -20,6 +20,7 @@
 #define ICEFLOW_SCALER_HPP
 
 #include "congestion-reporter.hpp"
+#include "node-instance-service.hpp"
 
 #include "iceflow.hpp"
 #include "producer.hpp"
@@ -58,6 +59,8 @@ private:
   const std::string &m_clientAddress;
 
   std::shared_ptr<IceFlow> m_iceflow;
+
+  std::shared_ptr<iceflow::NodeInstanceService> m_instanceService;
 
   std::unique_ptr<grpc::Server> m_server;
 

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -85,7 +85,7 @@ void IceflowExecutor::repartition(const std::string &edgeName,
     return;
   }
 
-  NDN_LOG_INFO("Received an error response.");
+  NDN_LOG_INFO("Received an error response: " << status.error_message());
 }
 
 void IceflowExecutor::receiveCongestionReport(CongestionReason congestionReason,

--- a/src/scaler.cpp
+++ b/src/scaler.cpp
@@ -44,11 +44,11 @@ IceflowScaler::~IceflowScaler() {
 }
 
 void IceflowScaler::runGrpcServer(const std::string &address) {
-  NodeInstanceService service(m_iceflow);
+  m_instanceService = std::make_shared<NodeInstanceService>(m_iceflow);
 
   grpc::ServerBuilder builder;
   builder.AddListeningPort(address, grpc::InsecureServerCredentials());
-  builder.RegisterService(&service);
+  builder.RegisterService(m_instanceService.get());
   m_server = builder.BuildAndStart();
   NDN_LOG_INFO("Server listening on " << address);
 }

--- a/src/services/node-instance-service.cpp
+++ b/src/services/node-instance-service.cpp
@@ -40,7 +40,8 @@ grpc::Status NodeInstanceService::Repartition(grpc::ServerContext *context,
                << lowerPartitionBound << "--" << upperPartitionBound << ".");
 
   auto partitions =
-      std::vector<uint32_t>(lowerPartitionBound, upperPartitionBound);
+      std::vector<uint32_t>(upperPartitionBound - lowerPartitionBound);
+  std::iota(partitions.begin(), partitions.end(), lowerPartitionBound);
 
   response->set_lower_partition_bound(lowerPartitionBound);
   response->set_upper_partition_bound(upperPartitionBound);


### PR DESCRIPTION
This PR fixes some smaller issues I noticed while working on the node executor:
- Added an error message if a GRPC error occurs in the executor.
- Fixed a segfault in the scaler.
- Fixed the `partitions` variable used for rescaling being set to a wrong value.
- Allow starting gRPC server and client on the executor-side separately, enable `wait_for_ready` for executor-side requests.
    - These changes were both necessary so that the executor can properly wait for the instance to come up before sending requests. Without them, the executor would just try to connect immediately after starting the server, which will fail if the client is not up yet (or the client crashed because it itself could not connect to the executor).