### PR TITLE
fix(dag-parser): use an empty object as default for envs and mounts

### DIFF
--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -54,11 +54,11 @@ DAGParser DAGParser::parseFromFile(const std::string &filename) {
     nodeInstance.container.image = containerJson.at("image").get<std::string>();
     nodeInstance.container.tag = containerJson.value("tag", "latest");
     nodeInstance.container.envs = std::map<std::string, std::string>();
-    auto envs = containerJson.at("envs").get<nlohmann::json>();
+    auto envs = containerJson.value("envs", json::object());
     for (const auto &[key, value] : envs.items()) {
       nodeInstance.container.envs.emplace(key, value.get<std::string>());
     }
-    auto mounts = containerJson.at("mounts").get<nlohmann::json>();
+    auto mounts = containerJson.value("mounts", json::object());
     for (const auto &[key, value] : mounts.items()) {
       nodeInstance.container.mounts.emplace(key, value.get<std::string>());
     }


### PR DESCRIPTION
Trying to use the examples locally, I noticed that they crashed at runtime, as the example DAG does neither provide an `envs` or `mounts` field at the moment. This PR resolves the issue by defaulting to an empty JSON object if there is no value present.