### PR TITLE
Add initial backchannel implementation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1728672398,
-        "narHash": "sha256-KxuGSoVUFnQLB2ZcYODW7AVPAh9JqRlD5BrfsC/Q4qs=",
+        "lastModified": 1737621947,
+        "narHash": "sha256-8HFvG7fvIFbgtaYAY2628Tb89fA55nPm2jSiNs0/Cws=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "aac51f698309fd0f381149214b7eee213c66ef0a",
+        "rev": "f65a3cd5e339c223471e64c051434616e18cc4f5",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736426010,
-        "narHash": "sha256-d0rE+u8/rQjXLvDobz1StGTfqvRKvq+8kVsHnIGVD1o=",
+        "lastModified": 1740851740,
+        "narHash": "sha256-urr8VnD7dXWd6io9DmwVlboa0Or9ygsahx1UAft7ZxY=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "1c384bc4be3ee571511fbbc6fdc94fe47d60f6cf",
+        "rev": "56e488989b3d72cd8e30ddd419e879658609bf88",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -99,17 +99,14 @@
         "nixpkgs": [
           "devenv",
           "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "devenv"
         ]
       },
       "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
+        "lastModified": 1740849354,
+        "narHash": "sha256-oy33+t09FraucSZ2rZ6qnD1Y1c8azKKmQuCvF2ytUko=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
+        "rev": "4a709a8ce9f8c08fa7ddb86761fe488ff7858a07",
         "type": "github"
       },
       "original": {
@@ -175,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727438425,
-        "narHash": "sha256-X8ES7I1cfNhR9oKp06F6ir4Np70WGZU5sfCOuNBEwMg=",
+        "lastModified": 1734114420,
+        "narHash": "sha256-n52PUzub5jZWc8nI/sR7UICOheU8rNA+YZ73YaHeCBg=",
         "owner": "domenkozar",
         "repo": "nix",
-        "rev": "f6c5ae4c1b2e411e6b1e6a8181cc84363d6a7546",
+        "rev": "bde6a1a0d1f2af86caa4d20d23eca019f3d57eee",
         "type": "github"
       },
       "original": {
@@ -191,11 +188,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730531603,
-        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
+        "lastModified": 1733212471,
+        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
+        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
         "type": "github"
       },
       "original": {
@@ -223,11 +220,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1736684107,
-        "narHash": "sha256-vH5mXxEvZeoGNkqKoCluhTGfoeXCZ1seYhC2pbMN0sg=",
+        "lastModified": 1740865531,
+        "narHash": "sha256-h00vGIh/jxcGl8aWdfnVRD74KuLpyY3mZgMFMy7iKIc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "635e887b48521e912a516625eee7df6cf0eba9c1",
+        "rev": "5ef6c425980847c78a80d759abc476e941a9bf42",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,10 +24,10 @@
           version = "dev";
 
           src = prev.fetchFromGitHub {
-            owner = "named-data";
+            owner = "hsel-netsys";
             repo = "ndn-svs";
-            rev = "ec54124d79fcb1d4ee00038c8ed3a0cdd9ad4e8b";
-            sha256 = "sha256-BoT3G4CAhoq7CerZoOPgGlqRkVY6Arnax834YDAeohk=";
+            rev = "3e9074bf632e2c9a50148cb3595dd638408579cd";
+            sha256 = "sha256-f3oGJE4Td+AKZqIN8pbUsP/VpL6crMIqYnjOfVMUfZE=";
           };
 
           nativeBuildInputs = with prev; [ pkg-config wafHook python3 ];

--- a/include/iceflow/producer.hpp
+++ b/include/iceflow/producer.hpp
@@ -75,11 +75,16 @@ private:
   uint64_t determineIdleTime(
       std::chrono::time_point<std::chrono::steady_clock> referenceTimepoint);
 
+  void setupBackchannel();
+
 private:
   const std::weak_ptr<ndn::svs::SVSPubSub> m_svsPubSub;
+
   const std::string m_pubTopic;
 
   std::string m_nodePrefix;
+
+  std::string m_syncPrefix;
 
   uint32_t m_numberOfPartitions;
   std::unordered_set<uint32_t> m_topicPartitions;

--- a/src/iceflow.cpp
+++ b/src/iceflow.cpp
@@ -64,7 +64,7 @@ IceFlow::IceFlow(
     std::optional<std::shared_ptr<CongestionReporter>> congestionReporter)
     : m_face(face), m_congestionReporter(congestionReporter) {
   m_nodePrefix = generateNodePrefix(dagParser.getApplicationName());
-  m_syncPrefix = "/" + dagParser.getApplicationName();
+  m_syncPrefix = dagParser.getApplicationName();
 
   m_node = dagParser.findNodeByName(nodeName);
   m_downstreamEdges = m_node.downstream;


### PR DESCRIPTION
After much more time than expected, this PR now contains an initial implementation of the promised backchannel deletion feature to the library. For now, I've implemented this by using a second/different kind topic with a "backchannel" suffix, which can be used to report the sequence numbers that have been processed back to the producer. Currently, the sequence numbers are serialized as JSON, which should probably be replaced/refactored.

Unfortunately, there is currently not a real good way to prevent data from being added to the store, so the sequence numbers that are reported back will now gradually fill up the data store instead (in most cases, that will probably take up less space than the regular data, but still, not really ideal). So we should probably revisit the way we handle this later.

Lastly, before merging this PR, the overridden data store (that was needed to perform the deletion of data store entries) should probably be moved to a fork in order to prevent licensing issues with the GPL-licensed ndn-cxx library (where I took the basis of the class from). 