### PR TITLE
chore: disable gRPC support by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ project(
   DESCRIPTION "NDN-based stream processing library written in C++.")
 set(CMAKE_CXX_STANDARD 20)
 
-option(USE_GRPC "Enable gRPC support" ON)
+option(USE_GRPC "Enable gRPC support" OFF)
 
 find_package(Boost CONFIG)
 find_package(PkgConfig)

--- a/flake.nix
+++ b/flake.nix
@@ -57,8 +57,8 @@
         lib = nixpkgs.lib;
         iceflowPackage = ({crossTarget ? "${system}"}:  let
           pkgs = (import nixpkgs { localSystem = system; crossSystem = crossTarget; }).extend self.overlays.default;
-        in 
-          pkgs.callPackage ({enableExamples ? false, enableGRPC ? true, stdenv, pkgs}: stdenv.mkDerivation {
+        in
+          pkgs.callPackage ({enableExamples ? false, enableGRPC ? false, stdenv, pkgs}: stdenv.mkDerivation {
             name = "iceflow";
             src = ./.;
 

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
           name = "iceflow-${example_name}";
           tag = "latest";
 
-          contents = [ (self.packages."${system}".iceflow-cross."${crossTarget}".override {enableExamples = true;}) pkgs.busybox pkgs.libgcc];
+          contents = [ (self.packages."${system}".iceflow-cross."${crossTarget}".override {enableExamples = true; enableGRPC = true;}) pkgs.busybox pkgs.libgcc];
           architecture = crossTargetContainer;
           config = {
             Cmd = ["sh" "-c" (lib.concatStringsSep " " (["/bin/${example_name}" ] ++ args))];


### PR DESCRIPTION
With the recent changes to the wordcount examples, compiling them with gRPC support enabled causes them to not run properly anymore in some instances. To eliminate this source of confusion (at least for me), this PR proposes changing the CMakeLists.txt file to not enable gRPC support by default anymore.