### PR TITLE
fix(dag-parser): remove unused filename parameter from fromJson

### DIFF
--- a/include/iceflow/dag-parser.hpp
+++ b/include/iceflow/dag-parser.hpp
@@ -79,7 +79,7 @@ public:
 
   static DAGParser parseFromFile(const std::string &filename);
 
-  static DAGParser fromJson(nlohmann::json json, const std::string &filename);
+  static DAGParser fromJson(nlohmann::json json);
 
   const std::vector<Node> &getNodes();
 

--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -27,8 +27,7 @@ NDN_LOG_INIT(iceflow.DAGParser);
 DAGParser::DAGParser(const std::string &appName, std::vector<Node> &&nodeList)
     : m_applicationName(appName), nodes(std::move(nodeList)) {}
 
-DAGParser DAGParser::fromJson(nlohmann::json json,
-                              const std::string &filename) {
+DAGParser DAGParser::fromJson(nlohmann::json json) {
   std::string appName = json.at("applicationName").get<std::string>();
 
   std::vector<Node> nodeList;
@@ -98,7 +97,7 @@ DAGParser DAGParser::parseFromFile(const std::string &filename) {
   json dagParam;
   file >> dagParam;
 
-  return DAGParser::fromJson(dagParam, filename);
+  return DAGParser::fromJson(dagParam);
 }
 
 const std::vector<Node> &DAGParser::getNodes() { return nodes; }


### PR DESCRIPTION
In #135, I made a small mistake by including an unneeded `filename` parameter in the newly added `fromJson` method. This simple PR solves the issue.