### PR TITLE
Let DAG Parser expose Raw DAG

### DIFF
--- a/include/iceflow/dag-parser.hpp
+++ b/include/iceflow/dag-parser.hpp
@@ -77,6 +77,9 @@ class DAGParser {
 public:
   DAGParser(const std::string &appName, std::vector<Node> &&nodes);
 
+  DAGParser(const std::string &appName, std::vector<Node> &&nodeList,
+            std::optional<nlohmann::json> json);
+
   static DAGParser parseFromFile(const std::string &filename);
 
   static DAGParser fromJson(nlohmann::json json);
@@ -95,9 +98,13 @@ public:
   std::vector<std::pair<const Node &, const Edge &>>
   findUpstreamEdges(const Node &node);
 
+  std::optional<nlohmann::json> getRawDag();
+
 private:
   std::string m_applicationName;
   std::vector<Node> m_nodes;
+
+  std::optional<nlohmann::json> m_json;
 };
 
 } // namespace iceflow

--- a/include/iceflow/dag-parser.hpp
+++ b/include/iceflow/dag-parser.hpp
@@ -97,7 +97,7 @@ public:
 
 private:
   std::string m_applicationName;
-  std::vector<Node> nodes;
+  std::vector<Node> m_nodes;
 };
 
 } // namespace iceflow

--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -25,7 +25,7 @@ namespace iceflow {
 NDN_LOG_INIT(iceflow.DAGParser);
 
 DAGParser::DAGParser(const std::string &appName, std::vector<Node> &&nodeList)
-    : m_applicationName(appName), nodes(std::move(nodeList)) {}
+    : m_applicationName(appName), m_nodes(std::move(nodeList)) {}
 
 DAGParser DAGParser::fromJson(nlohmann::json json) {
   std::string appName = json.at("applicationName").get<std::string>();
@@ -100,17 +100,16 @@ DAGParser DAGParser::parseFromFile(const std::string &filename) {
   return DAGParser::fromJson(dagParam);
 }
 
-const std::vector<Node> &DAGParser::getNodes() { return nodes; }
+const std::vector<Node> &DAGParser::getNodes() { return m_nodes; }
 
 const std::string &DAGParser::getApplicationName() { return m_applicationName; }
 
 const Node &DAGParser::findNodeByName(const std::string &nodeName) {
-  auto it =
-      std::find_if(nodes.begin(), nodes.end(), [&nodeName](const Node &node) {
-        return node.name == nodeName;
-      });
+  auto it = std::find_if(
+      m_nodes.begin(), m_nodes.end(),
+      [&nodeName](const Node &node) { return node.name == nodeName; });
 
-  if (it != nodes.end()) {
+  if (it != m_nodes.end()) {
     return *it;
   }
 
@@ -118,7 +117,7 @@ const Node &DAGParser::findNodeByName(const std::string &nodeName) {
 }
 
 const Edge &DAGParser::findEdgeByName(const std::string &edgeId) {
-  for (const auto &node : nodes) {
+  for (const auto &node : m_nodes) {
     auto downstream = node.downstream;
 
     auto it =
@@ -142,7 +141,7 @@ std::vector<std::pair<const Node &, const Edge &>>
 DAGParser::findUpstreamEdges(const std::string &taskId) {
   std::vector<std::pair<const Node &, const Edge &>> upstreamEdges;
 
-  for (const auto &node : nodes) {
+  for (const auto &node : m_nodes) {
 
     auto it = std::find_if(
         node.downstream.begin(), node.downstream.end(),

--- a/src/dag-parser.cpp
+++ b/src/dag-parser.cpp
@@ -24,8 +24,12 @@ namespace iceflow {
 
 NDN_LOG_INIT(iceflow.DAGParser);
 
+DAGParser::DAGParser(const std::string &appName, std::vector<Node> &&nodeList,
+                     std::optional<nlohmann::json> json)
+    : m_applicationName(appName), m_nodes(std::move(nodeList)), m_json(json) {}
+
 DAGParser::DAGParser(const std::string &appName, std::vector<Node> &&nodeList)
-    : m_applicationName(appName), m_nodes(std::move(nodeList)) {}
+    : DAGParser(appName, std::move(nodeList), std::nullopt) {}
 
 DAGParser DAGParser::fromJson(nlohmann::json json) {
   std::string appName = json.at("applicationName").get<std::string>();
@@ -85,7 +89,8 @@ DAGParser DAGParser::fromJson(nlohmann::json json) {
     nodeList.push_back(nodeInstance);
   }
 
-  return DAGParser(appName, std::move(nodeList));
+  return DAGParser(appName, std::move(nodeList),
+                   std::optional<nlohmann::json>(json));
 }
 
 DAGParser DAGParser::parseFromFile(const std::string &filename) {
@@ -154,5 +159,7 @@ DAGParser::findUpstreamEdges(const std::string &taskId) {
 
   return upstreamEdges;
 }
+
+std::optional<nlohmann::json> DAGParser::getRawDag() { return m_json; }
 
 } // namespace iceflow


### PR DESCRIPTION
This PR addresses an issue we encountered in the node executor, where not exposing the raw DAG posed a problem for interacting with an executor from via the web API.